### PR TITLE
Redis connection adds keep alive

### DIFF
--- a/src/redis-shake/common/utils.go
+++ b/src/redis-shake/common/utils.go
@@ -283,21 +283,6 @@ func SendPSyncAck(bw *bufio.Writer, offset int64) error {
 	return redis.Encode(bw, cmd, true)
 }
 
-func KeepAlive(c redigo.Conn, exitC <-chan struct{}) {
-	var ticker = time.NewTicker(time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-exitC:
-			return
-		case <-ticker.C:
-			if _, err := c.Do("PING"); err != nil {
-				log.Infof("PING ", err)
-			}
-		}
-	}
-}
-
 // TODO
 func paclusterSlotsHB(c redigo.Conn) {
 	_, err := Values(c.Do("pacluster", "slotshb"))

--- a/src/redis-shake/common/utils.go
+++ b/src/redis-shake/common/utils.go
@@ -283,6 +283,21 @@ func SendPSyncAck(bw *bufio.Writer, offset int64) error {
 	return redis.Encode(bw, cmd, true)
 }
 
+func KeepAlive(c redigo.Conn, exitC <-chan struct{}) {
+	var ticker = time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-exitC:
+			return
+		case <-ticker.C:
+			if _, err := c.Do("PING"); err != nil {
+				log.Infof("PING ", err)
+			}
+		}
+	}
+}
+
 // TODO
 func paclusterSlotsHB(c redigo.Conn) {
 	_, err := Values(c.Do("pacluster", "slotshb"))

--- a/src/redis-shake/dbSync/syncRDB.go
+++ b/src/redis-shake/dbSync/syncRDB.go
@@ -28,6 +28,9 @@ func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType,
 				c := utils.OpenRedisConn(target, authType, passwd, conf.Options.TargetType == conf.RedisTypeCluster,
 					tlsEnable)
 				defer c.Close()
+				exitC := make(chan struct{})
+				defer close(exitC)
+				go utils.KeepAlive(c, exitC)
 				var lastdb uint32 = 0
 				for e := range pipe {
 					if filter.FilterDB(int(e.DB)) {

--- a/src/redis-shake/dbSync/syncRDB.go
+++ b/src/redis-shake/dbSync/syncRDB.go
@@ -28,9 +28,8 @@ func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType,
 				c := utils.OpenRedisConn(target, authType, passwd, conf.Options.TargetType == conf.RedisTypeCluster,
 					tlsEnable)
 				defer c.Close()
-				exitC := make(chan struct{})
-				defer close(exitC)
-				go utils.KeepAlive(c, exitC)
+				var ticker = time.NewTicker(time.Second)
+				defer ticker.Stop()
 				var lastdb uint32 = 0
 				for e := range pipe {
 					if filter.FilterDB(int(e.DB)) {
@@ -56,12 +55,26 @@ func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType,
 						if filter.FilterKey(string(e.Key)) == true {
 							// 1. judge if not pass filter key
 							ds.stat.fullSyncFilter.Incr()
+							select {
+							case <-ticker.C:
+								if _, err := c.Do("PING"); err != nil {
+									log.Infof("PING ", err)
+								}
+							default:
+							}
 							continue
 						} else {
 							slot := int(utils.KeyToSlot(string(e.Key)))
 							if filter.FilterSlot(slot) == true {
 								// 2. judge if not pass filter slot
 								ds.stat.fullSyncFilter.Incr()
+								select {
+								case <-ticker.C:
+									if _, err := c.Do("PING"); err != nil {
+										log.Infof("PING ", err)
+									}
+								default:
+								}
 								continue
 							}
 						}


### PR DESCRIPTION
Codis 集群之间同步数据的场景下，在使用按照 Key 的前缀过滤同步数据时，如果满足条件的 Key 占比太少，且目的端 `session_recv_timeout` 设置的比较小的话，可能会面临连接断开导致同步进程 panic 的情况，日志如下：

```c
2020/12/23 16:55:06 [INFO] DbSyncer[0] total = 2.48GB -     353.89MB [ 13%]  entry=7948943       filter=7948943
2020/12/23 16:55:06 [INFO] DbSyncer[1] total = 2.53GB -     406.94MB [ 15%]  entry=9142856       filter=9142855
2020/12/23 16:55:06 [INFO] DbSyncer[2] total = 2.49GB -     442.92MB [ 17%]  entry=9946662       filter=9946662
2020/12/23 16:55:06 [PANIC] del %!(EXTRA string=NOT_EXISTS_3, *errors.errorString=EOF)
[stack]:
    1   /Users/tongyao.lty/Work/RedisShake/src/redis-shake/common/utils.go:842
            redis-shake/common.RestoreRdbEntry
    0   /Users/tongyao.lty/Work/RedisShake/src/redis-shake/dbSync/syncRDB.go:68
            redis-shake/dbSync.(*DbSyncer).syncRDBFile.func1.1
        ... ...
```

通过对 Redis 连接增加 keep alive 机制，可避免这种 panic 发生，修改后运行日志如下：

```c
2020/12/23 17:02:01 [INFO] DbSyncer[0] total = 2.48GB -     464.16MB [ 18%]  entry=10424989      filter=10424989
2020/12/23 17:02:01 [INFO] DbSyncer[1] total = 2.53GB -     398.81MB [ 15%]  entry=8960493       filter=8960493
2020/12/23 17:02:01 [INFO] DbSyncer[2] total = 2.49GB -     455.54MB [ 17%]  entry=10230458      filter=10230457  // here
```