### PR TITLE
Support db convert map

### DIFF
--- a/conf/redis-shake.conf
+++ b/conf/redis-shake.conf
@@ -58,7 +58,7 @@ source.tls_enable = false
 # if the input is list split by semicolon(;), redis-shake will restore the list one by one.
 # 如果是decode或者restore，这个参数表示读取的rdb文件。支持输入列表，例如：rdb.0;rdb.1;rdb.2
 # redis-shake将会挨个进行恢复。
-source.rdb.input = local
+source.rdb.input = /home/chenyangyang.cy/redis-5.0/src/dump.rdb
 # the concurrence of RDB syncing, default is len(source.address) or len(source.rdb.input).
 # used in `dump`, `sync` and `restore`. 0 means default.
 # This is useless when source.type isn't cluster or only input is only one RDB.
@@ -86,13 +86,17 @@ target.type = standalone
 #   2. ${sentinel_master_name}:${master or slave}@sentinel single/cluster address, e.g., mymaster:master@127.0.0.1:26379;127.0.0.1:26380, or @127.0.0.1:26379;127.0.0.1:26380. for "sentinel" type.
 #   3. cluster that has several db nodes split by semicolon(;). for "cluster" type.
 #   4. proxy address. for "proxy" type.
-target.address = 127.0.0.1:20551
+target.address = 127.0.0.1:6379
 # password of db/proxy. even if type is sentinel.
 target.password_raw =
 # auth type, don't modify it
 target.auth_type = auth
 # all the data will be written into this db. < 0 means disable.
 target.db = -1
+# Format: 0-5;1-3 ,Indicates that the data of the source db0 is written to the target db5, and 
+# the data of the source db1 is all written to the target db3. 
+# Note: When target.db is specified, target.dbmap will not take effect.
+target.dbmap = 0-6;1-3
 # tls enable, true or false. Currently, only support standalone.
 # open source redis does NOT support tls so far, but some cloud versions do.
 target.tls_enable = false

--- a/src/redis-shake/configure/configure.go
+++ b/src/redis-shake/configure/configure.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	TargetPasswordRaw      string   `config:"target.password_raw"`
 	TargetPasswordEncoding string   `config:"target.password_encoding"`
 	TargetDBString         string   `config:"target.db"`
+	TargetDBMapString      string   `config:"target.dbmap"`
 	TargetAuthType         string   `config:"target.auth_type"`
 	TargetType             string   `config:"target.type"`
 	TargetTLSEnable        bool     `config:"target.tls_enable"`
@@ -80,6 +81,7 @@ type Configuration struct {
 	TargetDB          int           // int type
 	Version           string        // version
 	Type              string        // input mode -type=xxx
+	TargetDBMap       map[int]int   // target db map
 }
 
 var Options Configuration

--- a/src/redis-shake/dbSync/syncRDB.go
+++ b/src/redis-shake/dbSync/syncRDB.go
@@ -43,6 +43,9 @@ func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType,
 								lastdb = uint32(conf.Options.TargetDB)
 								utils.SelectDB(c, uint32(conf.Options.TargetDB))
 							}
+						} else if tdb, ok := conf.Options.TargetDBMap[int(e.DB)]; ok {
+							lastdb = uint32(tdb)
+							utils.SelectDB(c, lastdb)
 						} else {
 							if e.DB != lastdb {
 								lastdb = e.DB

--- a/src/redis-shake/restore.go
+++ b/src/redis-shake/restore.go
@@ -167,6 +167,9 @@ func (dr *dbRestorer) restoreRDBFile(reader *bufio.Reader, target []string, auth
 								lastdb = uint32(conf.Options.TargetDB)
 								utils.SelectDB(c, lastdb)
 							}
+						} else if tdb, ok := conf.Options.TargetDBMap[int(e.DB)]; ok {
+							lastdb = uint32(tdb)
+							utils.SelectDB(c, lastdb)
 						} else {
 							if e.DB != lastdb {
 								lastdb = e.DB

--- a/src/redis-shake/rump.go
+++ b/src/redis-shake/rump.go
@@ -364,7 +364,9 @@ func (dre *dbRumperExecutor) writer() {
 		}
 		if conf.Options.TargetDB != -1 {
 			ele.db = conf.Options.TargetDB
-		}
+		}  else if tdb, ok := conf.Options.TargetDBMap[int(ele.db)]; ok {
+			ele.db = tdb
+		} 
 
 		log.Debugf("dbRumper[%v] executor[%v] restore[%s], length[%v]", dre.rumperId, dre.executorId, ele.key,
 			len(ele.value))


### PR DESCRIPTION
issue [https://github.com/alibaba/RedisShake/issues/348](url).
Add `target.dbmap` config option, which format is : 0-5;1-3 , Indicates that the data of the source db0 is written to the target db5, and the data of the source db1 is all written to the target db3. 