### PR TITLE
WIP: feat: add custom sync and psync command support

### DIFF
--- a/conf/redis-shake.conf
+++ b/conf/redis-shake.conf
@@ -199,6 +199,9 @@ filter.slot =
 # converts to transaction(multi+{commands}+exec) which will be passed.
 # 控制不让lua脚本通过，true表示不通过
 filter.lua = false
+# filter flushall. true means not pass.
+# 控制不让flushall通过，true表示不通过
+filter.flushall = false
 
 # big key threshold, the default is 500 * 1024 * 1024 bytes. If the value is bigger than
 # this given value, all the field will be spilt and write into the target in order. If

--- a/conf/redis-shake.conf
+++ b/conf/redis-shake.conf
@@ -70,6 +70,16 @@ source.type = standalone
 #   2. cluster 模式需要配置所有 nodes 的 ip:port, 例如: source.address = 10.1.1.1:20331;10.1.1.2:20441
 source.address = 127.0.0.1:20441
 
+# ip:port#custom_sync_command
+# the address follows source.address style, and node list could be splitted by semicolon(;)
+# 地址格式和 source.address 一致，输入格式为"单个地址#自定义同步命令"
+# 注：目前只支持 cluster 模式
+source.custom_sync_command =
+
+# 类似 source.custom_sync_command，区别在于定制的是 psync 命令
+# 注：目前只支持 cluster 模式
+source.custom_psync_command =
+
 # source password, left blank means no password.
 # 源端密码，留空表示无密码。
 source.password_raw =

--- a/conf/redis-shake.conf
+++ b/conf/redis-shake.conf
@@ -195,6 +195,19 @@ filter.key.blacklist =
 # used in `sync`.
 # 指定过滤slot，只让指定的slot通过
 filter.slot =
+# filter give commands. multiple commands are separated by ';'.
+# e.g., "flushall;flushdb".
+# used in `sync`.
+# at most one of `filter.command.whitelist` and `filter.command.blacklist` parameters can be given.
+# if the filter.command.whitelist is not empty, the given commands will be passed while others filtered.
+# if the filter.command.blacklist is not empty, the given commands will be filtered.
+# besides, the other config caused filters also effect as usual, e.g. filter.lua = true would filter lua commands.
+# all the commands, except the other config caused filtered commands, will be passed if no condition given.
+# 只让指定命令通过，分号分隔
+filter.command.whitelist =
+# 不让指定命令通过，分号分隔
+# 除了这些指定的命令外，其他配置选项指定的过滤命令也会照常生效，如开启 filter.lua 将会过滤 lua 相关命令
+filter.command.blacklist =
 # filter lua script. true means not pass. However, in redis 5.0, the lua 
 # converts to transaction(multi+{commands}+exec) which will be passed.
 # 控制不让lua脚本通过，true表示不通过

--- a/src/pkg/redis/decoder.go
+++ b/src/pkg/redis/decoder.go
@@ -34,12 +34,9 @@ func Decode(r *bufio.Reader) (Resp, error) {
 }
 
 // return the response and current reading offset
-func MustDecodeOpt(d *Decoder) (Resp, int64) {
+func MustDecodeOpt(d *Decoder) (Resp, int64, error) {
 	resp, err := d.decodeResp(0)
-	if err != nil {
-		log.PanicError(err, "decode redis resp failed")
-	}
-	return resp, d.offset
+	return resp, d.offset, err
 }
 
 func MustDecode(r *bufio.Reader) Resp {
@@ -166,6 +163,7 @@ func (d *Decoder) decodeBulkBytes() ([]byte, error) {
 	d.offset += int64(len(b))
 
 	if b[n] != '\r' || b[n+1] != '\n' {
+		log.Errorf("got bad end data |||%#v|||", string(b))
 		return nil, errors.Trace(ErrBadRespCRLFEnd)
 	}
 	return b[:n], nil

--- a/src/redis-shake/checkpoint/checkpoint.go
+++ b/src/redis-shake/checkpoint/checkpoint.go
@@ -2,11 +2,12 @@ package checkpoint
 
 import (
 	"fmt"
-	"github.com/alibaba/RedisShake/pkg/libs/log"
-	"github.com/alibaba/RedisShake/redis-shake/common"
-	redigo "github.com/garyburd/redigo/redis"
 	"strconv"
 	"strings"
+
+	"github.com/alibaba/RedisShake/pkg/libs/log"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
+	redigo "github.com/garyburd/redigo/redis"
 )
 
 func LoadCheckpoint(dbSyncerId int, sourceAddr string, target []string, authType, passwd string,

--- a/src/redis-shake/checkpoint/checkpoint_test.go
+++ b/src/redis-shake/checkpoint/checkpoint_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"redis-shake/common"
+	utils "redis-shake/common"
 	"redis-shake/unit_test_common"
 
 	"github.com/stretchr/testify/assert"

--- a/src/redis-shake/common/configure.go
+++ b/src/redis-shake/common/configure.go
@@ -215,8 +215,8 @@ func parseAddress(tp, address, redisType string, isSource bool) error {
 					if !isSource {
 						endpoint = "target"
 					}
-					return fmt.Errorf("[%s] redis address should be all masters or all slaves, master:[%v], slave[%v]",
-						endpoint, masterAddressList, slaveAddressList)
+					return fmt.Errorf("[%s] redis address should be all masters or all slaves, input:[%v], master:[%v], slave[%v]",
+						endpoint, addressList, masterAddressList, slaveAddressList)
 				}
 			}
 

--- a/src/redis-shake/common/utils.go
+++ b/src/redis-shake/common/utils.go
@@ -190,11 +190,11 @@ func waitRdbDump(r io.Reader) <-chan int64 {
 			}
 		}
 		if rsp[0] != '$' {
-			log.Panicf("invalid sync response, rsp = '%s'", rsp)
+			log.Panicf("invalid sync response, no $ in head, rsp = '%#v'", rsp)
 		}
 		n, err := strconv.Atoi(rsp[1 : len(rsp)-2])
 		if err != nil || n <= 0 {
-			log.PanicErrorf(err, "invalid sync response = '%s', n = %d", rsp, n)
+			log.PanicErrorf(err, "invalid sync response = '%#v', n = %d", rsp, n)
 		}
 		size <- int64(n)
 	}()
@@ -238,6 +238,7 @@ func SendPSyncContinue(psyncCommand string, br *bufio.Reader, bw *bufio.Writer, 
 	}
 
 	cmd := redis.NewCommand(psyncCommand, runid, offset)
+	log.Infof("send command %s %s %d for continue psync", psyncCommand, runid, offset)
 	if err := redis.Encode(bw, cmd, true); err != nil {
 		log.PanicError(err, "write psync command failed, continue")
 	}
@@ -267,7 +268,7 @@ func SendPSyncContinue(psyncCommand string, br *bufio.Reader, bw *bufio.Writer, 
 			log.PanicError(err, "parse psync offset failed")
 		}
 
-		log.Infof("Event:FullSyncStart\tId:%s\t", conf.Options.Id)
+		log.Infof("Event:FullSyncStart\tId:%sOffset:%d\t", conf.Options.Id, v)
 		runid, offset := xx[1], v
 
 		return runid, offset, waitRdbDump(br)

--- a/src/redis-shake/configure/configure.go
+++ b/src/redis-shake/configure/configure.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	FilterKeyBlacklist       []string `config:"filter.key.blacklist"`
 	FilterSlot               []string `config:"filter.slot"`
 	FilterLua                bool     `config:"filter.lua"`
+	FilterFlushall           bool     `config:"filter.flushall"`
 	BigKeyThreshold          uint64   `config:"big_key_threshold"`
 	Metric                   bool     `config:"metric"`
 	MetricPrintLog           bool     `config:"metric.print_log"`

--- a/src/redis-shake/configure/configure.go
+++ b/src/redis-shake/configure/configure.go
@@ -7,52 +7,54 @@ type Configuration struct {
 	ConfVersion uint `config:"conf.version"` // do not modify the tag name
 
 	// config file variables
-	Id                     string   `config:"id"`
-	LogFile                string   `config:"log.file"`
-	LogLevel               string   `config:"log.level"`
-	SystemProfile          int      `config:"system_profile"`
-	HttpProfile            int      `config:"http_profile"`
-	Parallel               int      `config:"parallel"`
-	SourceType             string   `config:"source.type"`
-	SourceAddress          string   `config:"source.address"`
-	SourcePasswordRaw      string   `config:"source.password_raw"`
-	SourcePasswordEncoding string   `config:"source.password_encoding"`
-	SourceAuthType         string   `config:"source.auth_type"`
-	SourceTLSEnable        bool     `config:"source.tls_enable"`
-	SourceRdbInput         []string `config:"source.rdb.input"`
-	SourceRdbParallel      int      `config:"source.rdb.parallel"`
-	SourceRdbSpecialCloud  string   `config:"source.rdb.special_cloud"`
-	TargetAddress          string   `config:"target.address"`
-	TargetPasswordRaw      string   `config:"target.password_raw"`
-	TargetPasswordEncoding string   `config:"target.password_encoding"`
-	TargetDBString         string   `config:"target.db"`
-	TargetDBMapString      string   `config:"target.dbmap"`
-	TargetAuthType         string   `config:"target.auth_type"`
-	TargetType             string   `config:"target.type"`
-	TargetTLSEnable        bool     `config:"target.tls_enable"`
-	TargetRdbOutput        string   `config:"target.rdb.output"`
-	TargetVersion          string   `config:"target.version"`
-	FakeTime               string   `config:"fake_time"`
-	KeyExists              string   `config:"key_exists"`
-	FilterDBWhitelist      []string `config:"filter.db.whitelist"`
-	FilterDBBlacklist      []string `config:"filter.db.blacklist"`
-	FilterKeyWhitelist     []string `config:"filter.key.whitelist"`
-	FilterKeyBlacklist     []string `config:"filter.key.blacklist"`
-	FilterSlot             []string `config:"filter.slot"`
-	FilterLua              bool     `config:"filter.lua"`
-	BigKeyThreshold        uint64   `config:"big_key_threshold"`
-	Metric                 bool     `config:"metric"`
-	MetricPrintLog         bool     `config:"metric.print_log"`
-	SenderSize             uint64   `config:"sender.size"`
-	SenderCount            uint     `config:"sender.count"`
-	SenderDelayChannelSize uint     `config:"sender.delay_channel_size"`
-	KeepAlive              uint     `config:"keep_alive"`
-	PidPath                string   `config:"pid_path"`
-	ScanKeyNumber          uint32   `config:"scan.key_number"`
-	ScanSpecialCloud       string   `config:"scan.special_cloud"`
-	ScanKeyFile            string   `config:"scan.key_file"`
-	Qps                    int      `config:"qps"`
-	ResumeFromBreakPoint   bool     `config:"resume_from_break_point"`
+	Id                       string   `config:"id"`
+	LogFile                  string   `config:"log.file"`
+	LogLevel                 string   `config:"log.level"`
+	SystemProfile            int      `config:"system_profile"`
+	HttpProfile              int      `config:"http_profile"`
+	Parallel                 int      `config:"parallel"`
+	SourceType               string   `config:"source.type"`
+	SourceAddress            string   `config:"source.address"`
+	SourcePasswordRaw        string   `config:"source.password_raw"`
+	SourcePasswordEncoding   string   `config:"source.password_encoding"`
+	SourceAuthType           string   `config:"source.auth_type"`
+	SourceTLSEnable          bool     `config:"source.tls_enable"`
+	SourceRdbInput           []string `config:"source.rdb.input"`
+	SourceRdbParallel        int      `config:"source.rdb.parallel"`
+	SourceRdbSpecialCloud    string   `config:"source.rdb.special_cloud"`
+	SourceCustomSyncCommand  string   `config:"source.custom_sync_command"`
+	SourceCustomPsyncCommand string   `config:"source.custom_psync_command"`
+	TargetAddress            string   `config:"target.address"`
+	TargetPasswordRaw        string   `config:"target.password_raw"`
+	TargetPasswordEncoding   string   `config:"target.password_encoding"`
+	TargetDBString           string   `config:"target.db"`
+	TargetDBMapString        string   `config:"target.dbmap"`
+	TargetAuthType           string   `config:"target.auth_type"`
+	TargetType               string   `config:"target.type"`
+	TargetTLSEnable          bool     `config:"target.tls_enable"`
+	TargetRdbOutput          string   `config:"target.rdb.output"`
+	TargetVersion            string   `config:"target.version"`
+	FakeTime                 string   `config:"fake_time"`
+	KeyExists                string   `config:"key_exists"`
+	FilterDBWhitelist        []string `config:"filter.db.whitelist"`
+	FilterDBBlacklist        []string `config:"filter.db.blacklist"`
+	FilterKeyWhitelist       []string `config:"filter.key.whitelist"`
+	FilterKeyBlacklist       []string `config:"filter.key.blacklist"`
+	FilterSlot               []string `config:"filter.slot"`
+	FilterLua                bool     `config:"filter.lua"`
+	BigKeyThreshold          uint64   `config:"big_key_threshold"`
+	Metric                   bool     `config:"metric"`
+	MetricPrintLog           bool     `config:"metric.print_log"`
+	SenderSize               uint64   `config:"sender.size"`
+	SenderCount              uint     `config:"sender.count"`
+	SenderDelayChannelSize   uint     `config:"sender.delay_channel_size"`
+	KeepAlive                uint     `config:"keep_alive"`
+	PidPath                  string   `config:"pid_path"`
+	ScanKeyNumber            uint32   `config:"scan.key_number"`
+	ScanSpecialCloud         string   `config:"scan.special_cloud"`
+	ScanKeyFile              string   `config:"scan.key_file"`
+	Qps                      int      `config:"qps"`
+	ResumeFromBreakPoint     bool     `config:"resume_from_break_point"`
 
 	/*---------------------------------------------------------*/
 	// inner variables
@@ -72,16 +74,18 @@ type Configuration struct {
 
 	/*---------------------------------------------------------*/
 	// generated variables
-	SourceAddressList []string      // source address list
-	TargetAddressList []string      // target address list
-	SourceVersion     string        // source version
-	HeartbeatIp       string        // heartbeat ip
-	ShiftTime         time.Duration // shift
-	TargetReplace     bool          // to_replace
-	TargetDB          int           // int type
-	Version           string        // version
-	Type              string        // input mode -type=xxx
-	TargetDBMap       map[int]int   // target db map
+	SourceAddressList           []string          // source address list
+	TargetAddressList           []string          // target address list
+	SourceCustomSyncCommandMap  map[string]string // source address with custom sync command
+	SourceCustomPsyncCommandMap map[string]string // source address with custom psync command
+	SourceVersion               string            // source version
+	HeartbeatIp                 string            // heartbeat ip
+	ShiftTime                   time.Duration     // shift
+	TargetReplace               bool              // to_replace
+	TargetDB                    int               // int type
+	Version                     string            // version
+	Type                        string            // input mode -type=xxx
+	TargetDBMap                 map[int]int       // target db map
 }
 
 var Options Configuration

--- a/src/redis-shake/configure/configure.go
+++ b/src/redis-shake/configure/configure.go
@@ -41,6 +41,8 @@ type Configuration struct {
 	FilterKeyWhitelist       []string `config:"filter.key.whitelist"`
 	FilterKeyBlacklist       []string `config:"filter.key.blacklist"`
 	FilterSlot               []string `config:"filter.slot"`
+	FilterCommandWhitelist   []string `config:"filter.command.whitelist"`
+	FilterCommandBlacklist   []string `config:"filter.command.blacklist"`
 	FilterLua                bool     `config:"filter.lua"`
 	FilterFlushall           bool     `config:"filter.flushall"`
 	BigKeyThreshold          uint64   `config:"big_key_threshold"`

--- a/src/redis-shake/dbSync/dbSyncer.go
+++ b/src/redis-shake/dbSync/dbSyncer.go
@@ -2,24 +2,27 @@ package dbSync
 
 import (
 	"bufio"
-	"github.com/alibaba/RedisShake/pkg/libs/log"
-	"github.com/alibaba/RedisShake/redis-shake/base"
-	"github.com/alibaba/RedisShake/redis-shake/common"
-	"github.com/alibaba/RedisShake/redis-shake/heartbeat"
-	"github.com/alibaba/RedisShake/redis-shake/metric"
 	"io"
 
+	"github.com/alibaba/RedisShake/pkg/libs/log"
+	"github.com/alibaba/RedisShake/redis-shake/base"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
+	"github.com/alibaba/RedisShake/redis-shake/heartbeat"
+	"github.com/alibaba/RedisShake/redis-shake/metric"
+
 	"github.com/alibaba/RedisShake/redis-shake/checkpoint"
-	"github.com/alibaba/RedisShake/redis-shake/configure"
+	conf "github.com/alibaba/RedisShake/redis-shake/configure"
 )
 
 // one sync link corresponding to one DbSyncer
-func NewDbSyncer(id int, source, sourcePassword string, target []string, targetPassword string,
+func NewDbSyncer(id int, source, sourcePassword, sourceSyncCommand, sourcePsyncCommand string, target []string, targetPassword string,
 	slotLeftBoundary, slotRightBoundary int, httpPort int) *DbSyncer {
 	ds := &DbSyncer{
 		id:                         id,
 		source:                     source,
 		sourcePassword:             sourcePassword,
+		sourceSyncCommand:          sourceSyncCommand,
+		sourcePsyncCommand:         sourcePsyncCommand,
 		target:                     target,
 		targetPassword:             targetPassword,
 		slotLeftBoundary:           slotLeftBoundary,
@@ -39,8 +42,11 @@ func NewDbSyncer(id int, source, sourcePassword string, target []string, targetP
 type DbSyncer struct {
 	id int // current id in all syncer
 
-	source            string   // source address
-	sourcePassword    string   // source password
+	source             string // source address
+	sourcePassword     string // source password
+	sourceSyncCommand  string // sync command, default is 'sync'
+	sourcePsyncCommand string // psync command, default is 'psync'
+
 	target            []string // target address
 	targetPassword    string   // target password
 	runId             string   // source runId

--- a/src/redis-shake/dbSync/dbSyncer.go
+++ b/src/redis-shake/dbSync/dbSyncer.go
@@ -114,9 +114,11 @@ func (ds *DbSyncer) Sync() {
 	var input io.ReadCloser
 	var nsize int64
 	var isFullSync bool
+	hasReconnSource := make(chan bool)
+	didReconn := make(chan bool)
 	if conf.Options.Psync {
 		input, nsize, isFullSync, runId = ds.sendPSyncCmd(ds.source, conf.Options.SourceAuthType, ds.sourcePassword,
-			conf.Options.SourceTLSEnable, runId, offset)
+			conf.Options.SourceTLSEnable, runId, offset, hasReconnSource, didReconn)
 		ds.runId = runId
 	} else {
 		// sync
@@ -152,5 +154,5 @@ func (ds *DbSyncer) Sync() {
 	// sync increment
 	base.Status = "incr"
 	close(ds.WaitFull)
-	ds.syncCommand(reader, ds.target, conf.Options.TargetAuthType, ds.targetPassword, conf.Options.TargetTLSEnable, dbid)
+	ds.syncCommand(reader, ds.target, conf.Options.TargetAuthType, ds.targetPassword, conf.Options.TargetTLSEnable, dbid, hasReconnSource, didReconn)
 }

--- a/src/redis-shake/dbSync/dbSyncer.go
+++ b/src/redis-shake/dbSync/dbSyncer.go
@@ -114,11 +114,9 @@ func (ds *DbSyncer) Sync() {
 	var input io.ReadCloser
 	var nsize int64
 	var isFullSync bool
-	hasReconnSource := make(chan bool)
-	didReconn := make(chan bool)
 	if conf.Options.Psync {
 		input, nsize, isFullSync, runId = ds.sendPSyncCmd(ds.source, conf.Options.SourceAuthType, ds.sourcePassword,
-			conf.Options.SourceTLSEnable, runId, offset, hasReconnSource, didReconn)
+			conf.Options.SourceTLSEnable, runId, offset)
 		ds.runId = runId
 	} else {
 		// sync
@@ -154,5 +152,5 @@ func (ds *DbSyncer) Sync() {
 	// sync increment
 	base.Status = "incr"
 	close(ds.WaitFull)
-	ds.syncCommand(reader, ds.target, conf.Options.TargetAuthType, ds.targetPassword, conf.Options.TargetTLSEnable, dbid, hasReconnSource, didReconn)
+	ds.syncCommand(reader, ds.target, conf.Options.TargetAuthType, ds.targetPassword, conf.Options.TargetTLSEnable, dbid)
 }

--- a/src/redis-shake/dbSync/dbSyncer.go
+++ b/src/redis-shake/dbSync/dbSyncer.go
@@ -75,12 +75,13 @@ type DbSyncer struct {
 
 func (ds *DbSyncer) GetExtraInfo() map[string]interface{} {
 	return map[string]interface{}{
-		"SourceAddress":      ds.source,
-		"TargetAddress":      ds.target,
-		"SenderBufCount":     len(ds.sendBuf),
-		"ProcessingCmdCount": len(ds.delayChannel),
-		"TargetDBOffset":     ds.stat.targetOffset.Get(),
-		"SourceDBOffset":     ds.stat.sourceOffset,
+		"SourceAddress":        ds.source,
+		"TargetAddress":        ds.target,
+		"SenderBufCount":       len(ds.sendBuf),
+		"ProcessingCmdCount":   len(ds.delayChannel),
+		"TargetDBOffset":       ds.stat.targetOffset.Get(),
+		"SourceMasterDBOffset": ds.stat.sourceMasterOffset.Get(),
+		"SourceDBOffset":       ds.stat.sourceOffset.Get(),
 	}
 }
 

--- a/src/redis-shake/dbSync/status.go
+++ b/src/redis-shake/dbSync/status.go
@@ -3,14 +3,15 @@ package dbSync
 import "github.com/alibaba/RedisShake/pkg/libs/atomic2"
 
 type Status struct {
-	rBytes         atomic2.Int64 // read bytes
-	wBytes         atomic2.Int64 // write bytes
-	wCommands      atomic2.Int64 // write commands (forward)
-	keys           atomic2.Int64 // total key number (nentry)
-	fullSyncFilter atomic2.Int64 // filtered keys in full sync (ignore)
-	incrSyncFilter atomic2.Int64 // filtered keys in increase sync (nbypass)
-	targetOffset   atomic2.Int64 // target offset
-	sourceOffset   int64         // source offset
+	rBytes             atomic2.Int64 // read bytes
+	wBytes             atomic2.Int64 // write bytes
+	wCommands          atomic2.Int64 // write commands (forward)
+	keys               atomic2.Int64 // total key number (nentry)
+	fullSyncFilter     atomic2.Int64 // filtered keys in full sync (ignore)
+	incrSyncFilter     atomic2.Int64 // filtered keys in increase sync (nbypass)
+	targetOffset       atomic2.Int64 // target offset
+	sourceOffset       atomic2.Int64 // source offset
+	sourceMasterOffset atomic2.Int64 // source master offset
 }
 
 func (s *Status) Stat() *syncerStat {

--- a/src/redis-shake/dbSync/syncBegin.go
+++ b/src/redis-shake/dbSync/syncBegin.go
@@ -45,7 +45,7 @@ func (ds *DbSyncer) sendPSyncCmd(master, authType, passwd string, tlsEnable bool
 	// writer buffer bind to client
 	bw := bufio.NewWriterSize(c, utils.WriterBufferSize)
 
-	log.Infof("DbSyncer[%d] try to send %s command: run-id[%v], offset[%v]", ds.id, ds.sourcePsyncCommand, runId, prevOffset)
+	log.Infof("DbSyncer[%d] try to send command: %s run-id[%v], offset[%v]", ds.id, ds.sourcePsyncCommand, runId, prevOffset)
 	// send psync command and decode the result
 	runid, offset, wait := utils.SendPSyncContinue(ds.sourcePsyncCommand, br, bw, runId, prevOffset)
 	ds.stat.targetOffset.Set(offset)

--- a/src/redis-shake/dbSync/syncIncrease.go
+++ b/src/redis-shake/dbSync/syncIncrease.go
@@ -4,22 +4,22 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/alibaba/RedisShake/pkg/libs/atomic2"
-	"github.com/alibaba/RedisShake/pkg/libs/log"
-	"github.com/alibaba/RedisShake/pkg/redis"
-	"github.com/alibaba/RedisShake/redis-shake/common"
-	"github.com/alibaba/RedisShake/redis-shake/configure"
-	"github.com/alibaba/RedisShake/redis-shake/filter"
 	"io"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
+	"github.com/alibaba/RedisShake/pkg/libs/atomic2"
+	"github.com/alibaba/RedisShake/pkg/libs/log"
+	"github.com/alibaba/RedisShake/pkg/redis"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
+	conf "github.com/alibaba/RedisShake/redis-shake/configure"
+	"github.com/alibaba/RedisShake/redis-shake/filter"
 	"github.com/alibaba/RedisShake/redis-shake/metric"
 
 	redigo "github.com/garyburd/redigo/redis"
-	"unsafe"
 )
 
 func (ds *DbSyncer) syncCommand(reader *bufio.Reader, target []string, authType, passwd string, tlsEnable bool, dbid int) {
@@ -200,7 +200,7 @@ func (ds *DbSyncer) parseSourceCommand(reader *bufio.Reader) {
 					bypass = filter.FilterDB(n)
 					isSelect = true
 					selectDB = n
-				} else if filter.FilterCommands(sCmd) {
+				} else if filter.FilterCommands(sCmd, argv) {
 					ignoreCmd = true
 				} else if strings.EqualFold(sCmd, "publish") && strings.EqualFold(string(argv[0]), "__sentinel__:hello") {
 					ignoresentinel = true

--- a/src/redis-shake/dbSync/syncIncrease.go
+++ b/src/redis-shake/dbSync/syncIncrease.go
@@ -349,8 +349,8 @@ func (ds *DbSyncer) sendTargetCommand(c redigo.Conn) {
 		ds.addSendId(&sendId, len(cachedTunnel))
 		for _, cacheItem := range cachedTunnel {
 			if err := c.Send(cacheItem.Cmd, cacheItem.Args...); err != nil {
-				log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tError:%s\t",
-					ds.id, conf.Options.Id, err.Error())
+				log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tCMD:%s, Args:%v\tError:%s\t",
+					ds.id, conf.Options.Id, cacheItem.Cmd, cacheItem.Args, err.Error())
 			}
 
 			// print debug log of send command
@@ -373,30 +373,30 @@ func (ds *DbSyncer) sendTargetCommand(c redigo.Conn) {
 				ds.addSendId(&sendId, 2)
 				// run id
 				if err := c.Send("hset", ds.checkpointName, checkpointRunId, ds.runId); err != nil {
-					log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tError:%s\t",
-						ds.id, conf.Options.Id, err.Error())
+					log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tCMD:hset, checkpointName:%s\tError:%s\t",
+						ds.id, conf.Options.Id, ds.checkpointName, err.Error())
 				}
 				// version
 				if err := c.Send("hset", ds.checkpointName, checkpointVersion, utils.FcvCheckpoint.CurrentVersion); err != nil {
-					log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tError:%s\t",
-						ds.id, conf.Options.Id, err.Error())
+					log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tCMD:hset, checkpointName:%s\tError:%s\t",
+						ds.id, conf.Options.Id, ds.checkpointName, err.Error())
 				}
 			}
 
 			// add checkpoint
 			ds.addSendId(&sendId, 2)
 			if err := c.Send("hset", ds.checkpointName, checkpointOffset, offset); err != nil {
-				log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tError:%s\t",
-					ds.id, conf.Options.Id, err.Error())
+				log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tCMD:hset, checkpointName:%s\tError:%s\t",
+					ds.id, conf.Options.Id, ds.checkpointName, err.Error())
 			}
 			if err := c.Send("exec"); err != nil {
-				log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tError:%s\t",
+				log.Panicf("DbSyncer[%d] Event:SendToTargetFail\tId:%s\tCMD:exec\tError:%s\t",
 					ds.id, conf.Options.Id, err.Error())
 			}
 		}
 
 		if err := c.Flush(); err != nil {
-			log.Panicf("DbSyncer[%d] Event:FlushFail\tId:%s\tError:%s\t",
+			log.Panicf("DbSyncer[%d] Event:FlushFail\tId:%s\tCMD:flush\tError:%s\t",
 				ds.id, conf.Options.Id, err.Error())
 		}
 

--- a/src/redis-shake/dbSync/syncIncrease.go
+++ b/src/redis-shake/dbSync/syncIncrease.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/alibaba/RedisShake/pkg/libs/atomic2"
+	"github.com/alibaba/RedisShake/pkg/libs/errors"
 	"github.com/alibaba/RedisShake/pkg/libs/log"
 	"github.com/alibaba/RedisShake/pkg/redis"
 	utils "github.com/alibaba/RedisShake/redis-shake/common"
@@ -22,7 +23,7 @@ import (
 	redigo "github.com/garyburd/redigo/redis"
 )
 
-func (ds *DbSyncer) syncCommand(reader *bufio.Reader, target []string, authType, passwd string, tlsEnable bool, dbid int) {
+func (ds *DbSyncer) syncCommand(reader *bufio.Reader, target []string, authType, passwd string, tlsEnable bool, dbid int, hasReconnSource, didReconn chan bool) {
 	isCluster := conf.Options.TargetType == conf.RedisTypeCluster
 	c := utils.OpenRedisConnWithTimeout(target, authType, passwd, incrSyncReadeTimeout, incrSyncReadeTimeout, isCluster, tlsEnable)
 	defer c.Close()
@@ -37,7 +38,7 @@ func (ds *DbSyncer) syncCommand(reader *bufio.Reader, target []string, authType,
 	go ds.receiveTargetReply(c)
 
 	// parse command from source redis
-	go ds.parseSourceCommand(reader)
+	go ds.parseSourceCommand(reader, hasReconnSource, didReconn)
 
 	// do send to target
 	go ds.sendTargetCommand(c)
@@ -165,7 +166,20 @@ func (ds *DbSyncer) receiveTargetReply(c redigo.Conn) {
 	log.Panicf("DbSyncer[%d] something wrong if you see me", ds.id)
 }
 
-func (ds *DbSyncer) parseSourceCommand(reader *bufio.Reader) {
+func (ds *DbSyncer) waitReconn(didReconn chan bool, timeout time.Duration) (err error) {
+	ticker := time.NewTicker(timeout)
+	for {
+		select {
+		case <-didReconn:
+			return
+		case <-ticker.C:
+			err = errors.New("wait incr reconnect timeout")
+			return
+		}
+	}
+}
+
+func (ds *DbSyncer) parseSourceCommand(reader *bufio.Reader, hasReconnSource, didReconn chan bool) {
 	var (
 		lastDb        = -1
 		selectDB      = -1
@@ -198,8 +212,32 @@ func (ds *DbSyncer) parseSourceCommand(reader *bufio.Reader) {
 		ignoresentinel := false
 		ignoreCmd := false
 		isSelect = false
+
+		var (
+			resp       redis.Resp
+			incrOffset int64
+		)
+
 		// incrOffset is used to do resume from break-point job
-		resp, incrOffset := redis.MustDecodeOpt(decoder)
+		resp, incrOffset, err = redis.MustDecodeOpt(decoder)
+		if err != nil {
+			// the source conn within pSyncPipeCopy maybe broken
+			// let's re-try it.
+			select {
+			case <-hasReconnSource:
+				if !errors.Equal(err, redis.ErrBadRespCRLFEnd) {
+					log.PanicErrorf(err, "DbSyncer[%d] decode resp failed[%v] with an unknown error, should be ErrBadRespCRLFEnd", ds.id, err)
+				}
+				log.Warnf("DbSyncer[%d] decode resp failed[%v], do wait until conn recovered since it would be caused by source conn broken pipe", ds.id, err)
+				err := ds.waitReconn(didReconn, 30*time.Second)
+				if err != nil {
+					log.PanicErrorf(err, "DbSyncer[%d] wait reconn failed[%v]", err)
+				}
+				log.Infof("DbSyncer[%d] parse command rountine continued", ds.id)
+			default:
+				log.PanicErrorf(err, "DbSyncer[%d] decode resp failed[%v]", ds.id, err)
+			}
+		}
 
 		if sCmd, argv, err = redis.ParseArgs(resp); err != nil {
 			log.PanicErrorf(err, "DbSyncer[%d] parse command arguments failed[%v]", ds.id, err)

--- a/src/redis-shake/filter/filter.go
+++ b/src/redis-shake/filter/filter.go
@@ -20,6 +20,10 @@ func FilterCommands(cmd string, argv [][]byte) bool {
 		return true
 	}
 
+	if conf.Options.FilterFlushall && strings.EqualFold(cmd, "flushall") {
+		return true
+	}
+
 	if strings.EqualFold(cmd, "replconf") && len(argv) > 1 && strings.EqualFold(string(argv[0]), "TIMESTAMP") {
 		return true
 	}

--- a/src/redis-shake/filter/filter.go
+++ b/src/redis-shake/filter/filter.go
@@ -20,6 +20,21 @@ func FilterCommands(cmd string, argv [][]byte) bool {
 		return true
 	}
 
+	if len(conf.Options.FilterCommandWhitelist) != 0 {
+		if matchOne(cmd, conf.Options.FilterCommandWhitelist) {
+			return false
+		}
+		return true
+	}
+
+	if len(conf.Options.FilterCommandBlacklist) != 0 {
+		if matchOne(cmd, conf.Options.FilterCommandBlacklist) {
+			return true
+		}
+	}
+
+	// besides the blacklist, do the other filterings.
+
 	if conf.Options.FilterFlushall && strings.EqualFold(cmd, "flushall") {
 		return true
 	}

--- a/src/redis-shake/filter/filter.go
+++ b/src/redis-shake/filter/filter.go
@@ -1,10 +1,11 @@
 package filter
 
 import (
-	"github.com/alibaba/RedisShake/redis-shake/common"
-	"github.com/alibaba/RedisShake/redis-shake/configure"
 	"strconv"
 	"strings"
+
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
+	conf "github.com/alibaba/RedisShake/redis-shake/configure"
 )
 
 var (
@@ -14,8 +15,12 @@ var (
 )
 
 // return true means not pass
-func FilterCommands(cmd string) bool {
+func FilterCommands(cmd string, argv [][]byte) bool {
 	if strings.EqualFold(cmd, "opinfo") {
+		return true
+	}
+
+	if strings.EqualFold(cmd, "replconf") && len(argv) > 1 && strings.EqualFold(string(argv[0]), "TIMESTAMP") {
 		return true
 	}
 

--- a/src/redis-shake/main/sanitize.go
+++ b/src/redis-shake/main/sanitize.go
@@ -210,6 +210,9 @@ func SanitizeOptions(tp string) error {
 	if len(conf.Options.FilterKeyWhitelist) != 0 && len(conf.Options.FilterKeyBlacklist) != 0 {
 		return fmt.Errorf("only one of 'filter.key.whitelist' and 'filter.key.blacklist' can be given")
 	}
+	if len(conf.Options.FilterCommandWhitelist) != 0 && len(conf.Options.FilterCommandBlacklist) != 0 {
+		return fmt.Errorf("only one of 'filter.command.whitelist' and 'filter.command.blacklist' can be given")
+	}
 
 	if len(conf.Options.FilterSlot) > 0 {
 		for i, val := range conf.Options.FilterSlot {

--- a/src/redis-shake/main/sanitize.go
+++ b/src/redis-shake/main/sanitize.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/alibaba/RedisShake/pkg/libs/log"
-	"github.com/alibaba/RedisShake/redis-shake/common"
-	"github.com/alibaba/RedisShake/redis-shake/configure"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
+	conf "github.com/alibaba/RedisShake/redis-shake/configure"
 
 	logRotate "gopkg.in/natefinch/lumberjack.v2"
 )
@@ -68,6 +68,11 @@ func SanitizeOptions(tp string) error {
 	// parse source and target address and type
 	if err := utils.ParseAddress(tp); err != nil {
 		return fmt.Errorf("mode[%v] parse address failed[%v]", tp, err)
+	}
+
+	// parse source custom sync and psync command
+	if err := utils.ParseCustomCommandMap(tp); err != nil {
+		return fmt.Errorf("mode[%v] parse custom command failed[%v]", tp, err)
 	}
 
 	if tp == conf.TypeRestore || tp == conf.TypeDecode {

--- a/src/redis-shake/metric/metric.go
+++ b/src/redis-shake/metric/metric.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/alibaba/RedisShake/pkg/libs/log"
 	"github.com/alibaba/RedisShake/redis-shake/base"
-	"github.com/alibaba/RedisShake/redis-shake/configure"
+	conf "github.com/alibaba/RedisShake/redis-shake/configure"
 )
 
 const (
@@ -90,7 +90,8 @@ type Metric struct {
 	AvgDelay    Percent // ms
 	NetworkFlow Combine // +speed
 
-	FullSyncProgress uint64
+	FullSyncProgress     uint64
+	FakeSlaveDelayOffset uint64
 }
 
 func CreateMetric(r base.Runner) {
@@ -249,6 +250,15 @@ func (m *Metric) GetNetworkFlowTotal() interface{} {
 func (m *Metric) SetFullSyncProgress(dbSyncerID int, val uint64) {
 	m.FullSyncProgress = val
 	fullSyncProcessPercent.WithLabelValues(strconv.Itoa(dbSyncerID)).Set(float64(val))
+}
+
+func (m *Metric) SetFakeSlaveDelayOffset(dbSyncerID int, val uint64) {
+	m.FakeSlaveDelayOffset = val
+	fakeSlaveDelayOffset.WithLabelValues(strconv.Itoa(dbSyncerID)).Set(float64(val))
+}
+
+func (m *Metric) GetFakeSlaveDelayOffset() interface{} {
+	return m.FakeSlaveDelayOffset
 }
 
 func (m *Metric) GetFullSyncProgress() interface{} {

--- a/src/redis-shake/metric/prometheus_metrics.go
+++ b/src/redis-shake/metric/prometheus_metrics.go
@@ -3,7 +3,7 @@ package metric
 import (
 	"strconv"
 
-	"github.com/alibaba/RedisShake/redis-shake/common"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -68,6 +68,14 @@ var (
 			Namespace: metricNamespace,
 			Name:      "full_sync_process_percent",
 			Help:      "RedisShake full sync process (%)",
+		},
+		[]string{dbSyncerLabelName},
+	)
+	fakeSlaveDelayOffset = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Name:      "fake_slave_delay_offset",
+			Help:      "RedisShake fake slave delay offset",
 		},
 		[]string{dbSyncerLabelName},
 	)

--- a/src/redis-shake/metric/variables.go
+++ b/src/redis-shake/metric/variables.go
@@ -2,8 +2,9 @@ package metric
 
 import (
 	"fmt"
+
 	"github.com/alibaba/RedisShake/redis-shake/base"
-	"github.com/alibaba/RedisShake/redis-shake/common"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
 )
 
 type MetricRest struct {
@@ -28,6 +29,7 @@ type MetricRest struct {
 	ProcessingCmdCount   interface{} // length of delay channel
 	TargetDBOffset       interface{} // target redis offset
 	SourceDBOffset       interface{} // source redis offset
+	SourceMasterDBOffset interface{} // source redis master reply offset
 	SourceAddress        interface{}
 	TargetAddress        interface{}
 	Details              interface{} // other details info
@@ -78,6 +80,7 @@ func NewMetricRest() []MetricRest {
 			ProcessingCmdCount:   detailMap["ProcessingCmdCount"],
 			TargetDBOffset:       detailMap["TargetDBOffset"],
 			SourceDBOffset:       detailMap["SourceDBOffset"],
+			SourceMasterDBOffset: detailMap["SourceMasterDBOffset"],
 			SourceAddress:        detailMap["SourceAddress"],
 			TargetAddress:        detailMap["TargetAddress"],
 			Details:              detailMap["Details"],

--- a/src/redis-shake/sync.go
+++ b/src/redis-shake/sync.go
@@ -76,7 +76,7 @@ func (cmd *CmdSync) Main() {
 
 		sourcePsyncCMD := "psync"
 		if customPsyncCommand, exists := conf.Options.SourceCustomPsyncCommandMap[source]; exists {
-			sourceSyncCMD = customPsyncCommand
+			sourcePsyncCMD = customPsyncCommand
 		}
 
 		nd := syncNode{


### PR DESCRIPTION
Ref #373 , introducing `source.custom_sync_command`, `source.custom_psync_command` to clarify customized sync\psync command, it's only tested under redis cluster.

BTW, it tests passed while do full sync, but failed with increase, see error logs below:

```
2021/09/08 17:33:28 [PANIC] DbSyncer[0] Event:ErrorReply	Id:redis-shake	Command: [unknown]	Error: ERR Unrecognized REPLCONF option: TIMESTAMP
[stack]:
    0   github.com/alibaba/RedisShake/redis-shake/dbSync/syncIncrease.go:120
            github.com/alibaba/RedisShake/redis-shake/dbSync.(*DbSyncer).receiveTargetReply
        ... ...
```

I'm wondering if it's version issue.

