### PR TITLE
feat: add fakeSlaveDelayOffset metric and source master offset info.

### DIFF
--- a/src/redis-shake/dbSync/dbSyncer.go
+++ b/src/redis-shake/dbSync/dbSyncer.go
@@ -69,12 +69,13 @@ type DbSyncer struct {
 
 func (ds *DbSyncer) GetExtraInfo() map[string]interface{} {
 	return map[string]interface{}{
-		"SourceAddress":      ds.source,
-		"TargetAddress":      ds.target,
-		"SenderBufCount":     len(ds.sendBuf),
-		"ProcessingCmdCount": len(ds.delayChannel),
-		"TargetDBOffset":     ds.stat.targetOffset.Get(),
-		"SourceDBOffset":     ds.stat.sourceOffset,
+		"SourceAddress":        ds.source,
+		"TargetAddress":        ds.target,
+		"SenderBufCount":       len(ds.sendBuf),
+		"ProcessingCmdCount":   len(ds.delayChannel),
+		"TargetDBOffset":       ds.stat.targetOffset.Get(),
+		"SourceMasterDBOffset": ds.stat.sourceMasterOffset.Get(),
+		"SourceDBOffset":       ds.stat.sourceOffset.Get(),
 	}
 }
 

--- a/src/redis-shake/dbSync/status.go
+++ b/src/redis-shake/dbSync/status.go
@@ -3,14 +3,15 @@ package dbSync
 import "github.com/alibaba/RedisShake/pkg/libs/atomic2"
 
 type Status struct {
-	rBytes         atomic2.Int64 // read bytes
-	wBytes         atomic2.Int64 // write bytes
-	wCommands      atomic2.Int64 // write commands (forward)
-	keys           atomic2.Int64 // total key number (nentry)
-	fullSyncFilter atomic2.Int64 // filtered keys in full sync (ignore)
-	incrSyncFilter atomic2.Int64 // filtered keys in increase sync (nbypass)
-	targetOffset   atomic2.Int64 // target offset
-	sourceOffset   int64         // source offset
+	rBytes             atomic2.Int64 // read bytes
+	wBytes             atomic2.Int64 // write bytes
+	wCommands          atomic2.Int64 // write commands (forward)
+	keys               atomic2.Int64 // total key number (nentry)
+	fullSyncFilter     atomic2.Int64 // filtered keys in full sync (ignore)
+	incrSyncFilter     atomic2.Int64 // filtered keys in increase sync (nbypass)
+	targetOffset       atomic2.Int64 // target offset
+	sourceOffset       atomic2.Int64 // source offset
+	sourceMasterOffset atomic2.Int64 // source master offset
 }
 
 func (s *Status) Stat() *syncerStat {

--- a/src/redis-shake/metric/metric.go
+++ b/src/redis-shake/metric/metric.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/alibaba/RedisShake/pkg/libs/log"
 	"github.com/alibaba/RedisShake/redis-shake/base"
-	"github.com/alibaba/RedisShake/redis-shake/configure"
+	conf "github.com/alibaba/RedisShake/redis-shake/configure"
 )
 
 const (
@@ -90,7 +90,8 @@ type Metric struct {
 	AvgDelay    Percent // ms
 	NetworkFlow Combine // +speed
 
-	FullSyncProgress uint64
+	FullSyncProgress     uint64
+	FakeSlaveDelayOffset uint64
 }
 
 func CreateMetric(r base.Runner) {
@@ -249,6 +250,15 @@ func (m *Metric) GetNetworkFlowTotal() interface{} {
 func (m *Metric) SetFullSyncProgress(dbSyncerID int, val uint64) {
 	m.FullSyncProgress = val
 	fullSyncProcessPercent.WithLabelValues(strconv.Itoa(dbSyncerID)).Set(float64(val))
+}
+
+func (m *Metric) SetFakeSlaveDelayOffset(dbSyncerID int, val uint64) {
+	m.FakeSlaveDelayOffset = val
+	fakeSlaveDelayOffset.WithLabelValues(strconv.Itoa(dbSyncerID)).Set(float64(val))
+}
+
+func (m *Metric) GetFakeSlaveDelayOffset() interface{} {
+	return m.FakeSlaveDelayOffset
 }
 
 func (m *Metric) GetFullSyncProgress() interface{} {

--- a/src/redis-shake/metric/prometheus_metrics.go
+++ b/src/redis-shake/metric/prometheus_metrics.go
@@ -3,7 +3,7 @@ package metric
 import (
 	"strconv"
 
-	"github.com/alibaba/RedisShake/redis-shake/common"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -68,6 +68,14 @@ var (
 			Namespace: metricNamespace,
 			Name:      "full_sync_process_percent",
 			Help:      "RedisShake full sync process (%)",
+		},
+		[]string{dbSyncerLabelName},
+	)
+	fakeSlaveDelayOffset = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Name:      "fake_slave_delay_offset",
+			Help:      "RedisShake fake slave delay offset",
 		},
 		[]string{dbSyncerLabelName},
 	)

--- a/src/redis-shake/metric/variables.go
+++ b/src/redis-shake/metric/variables.go
@@ -2,8 +2,9 @@ package metric
 
 import (
 	"fmt"
+
 	"github.com/alibaba/RedisShake/redis-shake/base"
-	"github.com/alibaba/RedisShake/redis-shake/common"
+	utils "github.com/alibaba/RedisShake/redis-shake/common"
 )
 
 type MetricRest struct {
@@ -28,6 +29,7 @@ type MetricRest struct {
 	ProcessingCmdCount   interface{} // length of delay channel
 	TargetDBOffset       interface{} // target redis offset
 	SourceDBOffset       interface{} // source redis offset
+	SourceMasterDBOffset interface{} // source redis master reply offset
 	SourceAddress        interface{}
 	TargetAddress        interface{}
 	Details              interface{} // other details info
@@ -78,6 +80,7 @@ func NewMetricRest() []MetricRest {
 			ProcessingCmdCount:   detailMap["ProcessingCmdCount"],
 			TargetDBOffset:       detailMap["TargetDBOffset"],
 			SourceDBOffset:       detailMap["SourceDBOffset"],
+			SourceMasterDBOffset: detailMap["SourceMasterDBOffset"],
 			SourceAddress:        detailMap["SourceAddress"],
 			TargetAddress:        detailMap["TargetAddress"],
 			Details:              detailMap["Details"],


### PR DESCRIPTION
According [issue #336-comment](https://github.com/alibaba/RedisShake/issues/363#issuecomment-919667729), I'd like to add a new metric `fake_slave_delay_offset` for tracking the delay offset between source master and redis-shake.
