### PR TITLE
Add tls_skip_verify configuration

### DIFF
--- a/conf/redis-shake.conf
+++ b/conf/redis-shake.conf
@@ -79,6 +79,8 @@ source.auth_type = auth
 # tls enable, true or false. Currently, only support standalone.
 # open source redis does NOT support tls so far, but some cloud versions do.
 source.tls_enable = false
+# Whether to verify the validity of the redis certificate, true means verification, false means no verification
+source.tls_skip_verify = false
 # input RDB file.
 # used in `decode` and `restore`.
 # if the input is list split by semicolon(;), redis-shake will restore the list one by one.
@@ -133,6 +135,8 @@ target.dbmap =
 # tls enable, true or false. Currently, only support standalone.
 # open source redis does NOT support tls so far, but some cloud versions do.
 target.tls_enable = false
+# Whether to verify the validity of the redis certificate, true means verification, false means no verification
+target.tls_skip_verify = false
 # output RDB file prefix.
 # used in `decode` and `dump`.
 # 如果是decode或者dump，这个参数表示输出的rdb前缀，比如输入有3个db，那么dump分别是:

--- a/src/redis-shake/checkpoint/checkpoint.go
+++ b/src/redis-shake/checkpoint/checkpoint.go
@@ -10,8 +10,8 @@ import (
 )
 
 func LoadCheckpoint(dbSyncerId int, sourceAddr string, target []string, authType, passwd string,
-	checkpointName string, isCluster bool, tlsEnable bool) (string, int64, int, error) {
-	c := utils.OpenRedisConn(target, authType, passwd, isCluster, tlsEnable)
+	checkpointName string, isCluster bool, tlsEnable bool, tlsSkipVerify bool) (string, int64, int, error) {
+	c := utils.OpenRedisConn(target, authType, passwd, isCluster, tlsEnable, tlsSkipVerify)
 
 	// fetch logical db list
 	ret, err := c.Do("info", "keyspace")

--- a/src/redis-shake/common/command.go
+++ b/src/redis-shake/common/command.go
@@ -189,8 +189,8 @@ type SlotOwner struct {
 	SlotRightBoundary int
 }
 
-func GetSlotDistribution(target, authType, auth string, tlsEnable bool) ([]SlotOwner, error) {
-	c := OpenRedisConn([]string{target}, authType, auth, false, tlsEnable)
+func GetSlotDistribution(target, authType, auth string, tlsEnable bool, tlsSkipVerify bool) ([]SlotOwner, error) {
+	c := OpenRedisConn([]string{target}, authType, auth, false, tlsEnable, tlsSkipVerify)
 	defer c.Close()
 
 	content, err := c.Do("cluster", "slots")

--- a/src/redis-shake/common/configure.go
+++ b/src/redis-shake/common/configure.go
@@ -104,6 +104,12 @@ func parseAddress(tp, address, redisType string, isSource bool) error {
 			auth, password = conf.Options.TargetAuthType, conf.Options.TargetPasswordRaw
 		}
 		tls := isSource && conf.Options.SourceTLSEnable || !isSource && conf.Options.TargetTLSEnable
+		var tlsSkipVerify bool
+		if isSource {
+			tlsSkipVerify = conf.Options.SourceTLSSkipVerify
+		} else {
+			tlsSkipVerify = conf.Options.TargetTLSSkipVerify
+		}
 
 		if strings.Contains(address, AddressSplitter) {
 			arr := strings.Split(address, AddressSplitter)
@@ -129,7 +135,7 @@ func parseAddress(tp, address, redisType string, isSource bool) error {
 			}
 
 			// create client to fetch
-			client := OpenRedisConn(clusterList, auth, password, false, tls)
+			client := OpenRedisConn(clusterList, auth, password, false, tls, tlsSkipVerify)
 			if addressList, err := GetAllClusterNode(client, role, "address"); err != nil {
 				return err
 			} else {
@@ -142,7 +148,7 @@ func parseAddress(tp, address, redisType string, isSource bool) error {
 		} else {
 			// check source list legality: all master or all slave
 			addressList := strings.Split(address, AddressClusterSplitter)
-			client := OpenRedisConn(addressList, auth, password, false, tls)
+			client := OpenRedisConn(addressList, auth, password, false, tls, tlsSkipVerify)
 
 			// fetch master address and slave address, ignore error
 			masterAddressList, _ := GetAllClusterNode(client, conf.StandAloneRoleMaster, "address")

--- a/src/redis-shake/configure/configure.go
+++ b/src/redis-shake/configure/configure.go
@@ -19,6 +19,7 @@ type Configuration struct {
 	SourcePasswordEncoding string   `config:"source.password_encoding"`
 	SourceAuthType         string   `config:"source.auth_type"`
 	SourceTLSEnable        bool     `config:"source.tls_enable"`
+	SourceTLSSkipVerify    bool     `config:"source.tls_skip_verify"`
 	SourceRdbInput         []string `config:"source.rdb.input"`
 	SourceRdbParallel      int      `config:"source.rdb.parallel"`
 	SourceRdbSpecialCloud  string   `config:"source.rdb.special_cloud"`
@@ -30,6 +31,7 @@ type Configuration struct {
 	TargetAuthType         string   `config:"target.auth_type"`
 	TargetType             string   `config:"target.type"`
 	TargetTLSEnable        bool     `config:"target.tls_enable"`
+	TargetTLSSkipVerify    bool     `config:"target.tls_skip_verify"`
 	TargetRdbOutput        string   `config:"target.rdb.output"`
 	TargetVersion          string   `config:"target.version"`
 	FakeTime               string   `config:"fake_time"`

--- a/src/redis-shake/dbSync/syncBegin.go
+++ b/src/redis-shake/dbSync/syncBegin.go
@@ -17,8 +17,8 @@ import (
 
 // send command to source redis
 
-func (ds *DbSyncer) sendSyncCmd(master, authType, passwd string, tlsEnable bool) (net.Conn, int64) {
-	c, wait := utils.OpenSyncConn(master, authType, passwd, tlsEnable)
+func (ds *DbSyncer) sendSyncCmd(master, authType, passwd string, tlsEnable bool, tlsSkipVerify bool) (net.Conn, int64) {
+	c, wait := utils.OpenSyncConn(master, authType, passwd, tlsEnable, tlsSkipVerify)
 	for {
 		select {
 		case nsize := <-wait:
@@ -33,9 +33,9 @@ func (ds *DbSyncer) sendSyncCmd(master, authType, passwd string, tlsEnable bool)
 	}
 }
 
-func (ds *DbSyncer) sendPSyncCmd(master, authType, passwd string, tlsEnable bool, runId string,
+func (ds *DbSyncer) sendPSyncCmd(master, authType, passwd string, tlsEnable bool, tlsSkipVerify bool, runId string,
 	prevOffset int64) (pipe.Reader, int64, bool, string) {
-	c := utils.OpenNetConn(master, authType, passwd, tlsEnable)
+	c := utils.OpenNetConn(master, authType, passwd, tlsEnable, tlsSkipVerify)
 	log.Infof("DbSyncer[%d] psync connect '%v' with auth type[%v] OK!", ds.id, master, authType)
 
 	utils.SendPSyncListeningPort(c, conf.Options.HttpProfile)

--- a/src/redis-shake/dbSync/syncRDB.go
+++ b/src/redis-shake/dbSync/syncRDB.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alibaba/RedisShake/redis-shake/metric"
 )
 
-func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType, passwd string, nsize int64, tlsEnable bool) {
+func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType, passwd string, nsize int64, tlsEnable bool, tlsSkipVerify bool) {
 	pipe := utils.NewRDBLoader(reader, &ds.stat.rBytes, base.RDBPipeSize)
 	wait := make(chan struct{})
 	go func() {
@@ -26,7 +26,7 @@ func (ds *DbSyncer) syncRDBFile(reader *bufio.Reader, target []string, authType,
 			go func() {
 				defer wg.Done()
 				c := utils.OpenRedisConn(target, authType, passwd, conf.Options.TargetType == conf.RedisTypeCluster,
-					tlsEnable)
+					tlsEnable, tlsSkipVerify)
 				defer c.Close()
 				var lastdb uint32 = 0
 				for e := range pipe {

--- a/src/redis-shake/dump.go
+++ b/src/redis-shake/dump.go
@@ -119,7 +119,7 @@ func (dd *dbDumper) dump() (*bufio.Reader, *bufio.Writer, int64) {
 	defer dumpto.Close()
 
 	// send command and get the returned channel
-	master, nsize := dd.sendCmd(dd.source, conf.Options.SourceAuthType, dd.sourcePassword, conf.Options.SourceTLSEnable)
+	master, nsize := dd.sendCmd(dd.source, conf.Options.SourceAuthType, dd.sourcePassword, conf.Options.SourceTLSEnable, conf.Options.SourceTLSSkipVerify)
 	defer master.Close()
 
 	log.Infof("routine[%v] source db[%v] dump rdb file-size[%d]\n", dd.id, dd.source, nsize)
@@ -132,8 +132,8 @@ func (dd *dbDumper) dump() (*bufio.Reader, *bufio.Writer, int64) {
 	return reader, writer, nsize
 }
 
-func (dd *dbDumper) sendCmd(master, auth_type, passwd string, tlsEnable bool) (net.Conn, int64) {
-	c, wait := utils.OpenSyncConn(master, auth_type, passwd, tlsEnable)
+func (dd *dbDumper) sendCmd(master, auth_type, passwd string, tlsEnable bool, tlsSkipVerify bool) (net.Conn, int64) {
+	c, wait := utils.OpenSyncConn(master, auth_type, passwd, tlsEnable, tlsSkipVerify)
 	var nsize int64
 
 	// wait rdb dump finish

--- a/src/redis-shake/main/sanitize.go
+++ b/src/redis-shake/main/sanitize.go
@@ -318,7 +318,7 @@ func SanitizeOptions(tp string) error {
 			for _, address := range conf.Options.TargetAddressList {
 				// single connection even if the target is cluster
 				if v, err := utils.GetRedisVersion(address, conf.Options.TargetAuthType,
-					conf.Options.TargetPasswordRaw, conf.Options.TargetTLSEnable); err != nil {
+					conf.Options.TargetPasswordRaw, conf.Options.TargetTLSEnable, conf.Options.TargetTLSSkipVerify); err != nil {
 					return fmt.Errorf("get target redis version failed[%v]", err)
 				} else if conf.Options.TargetVersion != "" && conf.Options.TargetVersion != v {
 					return fmt.Errorf("target redis version is different: [%v %v]", conf.Options.TargetVersion, v)
@@ -351,7 +351,7 @@ func SanitizeOptions(tp string) error {
 		for _, address := range conf.Options.SourceAddressList {
 			// single connection even if the target is cluster
 			if v, err := utils.GetRedisVersion(address, conf.Options.SourceAuthType,
-				conf.Options.SourcePasswordRaw, conf.Options.SourceTLSEnable); err != nil {
+				conf.Options.SourcePasswordRaw, conf.Options.SourceTLSEnable, conf.Options.SourceTLSSkipVerify); err != nil {
 				return fmt.Errorf("get source redis version failed[%v]", err)
 			} else if conf.Options.SourceVersion != "" && conf.Options.SourceVersion != v {
 				return fmt.Errorf("source redis version is different: [%v %v]", conf.Options.SourceVersion, v)
@@ -410,7 +410,7 @@ func SanitizeOptions(tp string) error {
 	if tp == conf.TypeDump || (tp == conf.TypeSync || tp == conf.TypeRump) && conf.Options.BigKeyThreshold > 1 {
 		for _, address := range conf.Options.SourceAddressList {
 			check, err := utils.GetRDBChecksum(address, conf.Options.SourceAuthType,
-				conf.Options.SourcePasswordRaw, conf.Options.SourceTLSEnable)
+				conf.Options.SourcePasswordRaw, conf.Options.SourceTLSEnable, conf.Options.SourceTLSSkipVerify)
 			if err != nil {
 				// ignore
 				log.Warnf("fetch source rdb[%v] checksum failed[%v], ignore", address, err)
@@ -464,13 +464,13 @@ func SanitizeOptions(tp string) error {
 			// check slot distribution
 			// 1. get source slot distribution
 			srcSlot, err := utils.GetSlotDistribution(conf.Options.SourceAddressList[0], conf.Options.SourceAuthType,
-				conf.Options.SourcePasswordRaw, false)
+				conf.Options.SourcePasswordRaw, false, false)
 			if err != nil {
 				return fmt.Errorf("resume_from_break_point get source slot distribution failed: %v", err)
 			}
 			// 2. get source slot distribution
 			dstSlot, err := utils.GetSlotDistribution(conf.Options.TargetAddressList[0], conf.Options.TargetAuthType,
-				conf.Options.TargetPasswordRaw, false)
+				conf.Options.TargetPasswordRaw, false, false)
 			if err != nil {
 				return fmt.Errorf("resume_from_break_point get target slot distribution failed: %v", err)
 			}

--- a/src/redis-shake/rump.go
+++ b/src/redis-shake/rump.go
@@ -97,7 +97,7 @@ func (dr *dbRumper) getStats() map[string]interface{} {
 func (dr *dbRumper) run() {
 	// single connection
 	dr.client = utils.OpenRedisConn([]string{dr.address}, conf.Options.SourceAuthType,
-		conf.Options.SourcePasswordRaw, false, conf.Options.SourceTLSEnable)
+		conf.Options.SourcePasswordRaw, false, conf.Options.SourceTLSEnable, conf.Options.SourceTLSSkipVerify)
 
 	// some clouds may have several db under proxy
 	count, err := dr.getNode()
@@ -127,13 +127,13 @@ func (dr *dbRumper) run() {
 		}
 
 		sourceClient := utils.OpenRedisConn([]string{dr.address}, conf.Options.SourceAuthType,
-			conf.Options.SourcePasswordRaw, false, conf.Options.SourceTLSEnable)
+			conf.Options.SourcePasswordRaw, false, conf.Options.SourceTLSEnable, conf.Options.SourceTLSSkipVerify)
 		targetClient := utils.OpenRedisConn(target, conf.Options.TargetAuthType,
 			conf.Options.TargetPasswordRaw, conf.Options.TargetType == conf.RedisTypeCluster,
-			conf.Options.TargetTLSEnable)
+			conf.Options.TargetTLSEnable, conf.Options.TargetTLSSkipVerify)
 		targetBigKeyClient := utils.OpenRedisConn(target, conf.Options.TargetAuthType,
 			conf.Options.TargetPasswordRaw, conf.Options.TargetType == conf.RedisTypeCluster,
-			conf.Options.TargetTLSEnable)
+			conf.Options.TargetTLSEnable, conf.Options.TargetTLSSkipVerify)
 		executor := NewDbRumperExecutor(dr.id, i, sourceClient, targetClient, targetBigKeyClient, tencentNodeId)
 		dr.executors[i] = executor
 

--- a/src/redis-shake/sync.go
+++ b/src/redis-shake/sync.go
@@ -44,7 +44,7 @@ func (cmd *CmdSync) Main() {
 	var err error
 	if conf.Options.SourceType == conf.RedisTypeCluster && conf.Options.ResumeFromBreakPoint {
 		if slotDistribution, err = utils.GetSlotDistribution(conf.Options.SourceAddressList[0], conf.Options.SourceAuthType,
-			conf.Options.SourcePasswordRaw, false); err != nil {
+			conf.Options.SourcePasswordRaw, false, false); err != nil {
 			log.Errorf("get source slot distribution failed: %v", err)
 			return
 		}


### PR DESCRIPTION
添加tls_skip_verify配置，该配置的功能为：当tls_skip_verify为true时表示跳过对redis服务端的证书校验，为false表示不跳过证书校验。tls_skip_verify默认值为false。

什么时候会把tls_skip_verify设置为true: 源端或目标端（redis）开启了ssl，但是我们只想把数据同步过来或者同步过去，不想处理复杂的CA导入安装流程，此时就可以tls_skip_verify设置为true。