### PR TITLE
fix: fix a bug that faild to synchronize using scan mode when source …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ redis-shake is a tool for Redis data migration and data filtering.
 * ✅ Tested on Redis 5.0, Redis 6.0 and Redis 7.0
 * 🤗 Support custom filtering rules
 * 💪 Support large instance migration
-* 💖 Support `restore` mode and `sync` mode
+* 💖 Support `restore` mode, `sync` mode and `scan` mode
 * ☁️ Support Aliyun Redis and ElastiCache
 
 For older versions of redis-shake (support codis, twemproxy) please


### PR DESCRIPTION
…is cluster mode

Add cluster determination for source redis server in scan mode. When server is in cluster mode, only scan db 0.


Fixes #540 