### PR TITLE
add feature about flush db before sync

### DIFF
--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -96,6 +96,10 @@ func main() {
 	// create status
 	status.Init(theReader, theWriter)
 
+	if config.Opt.Advanced.EmptyDBBeforeSync {
+		theWriter.Flush()
+	}
+
 	log.Infof("start syncing...")
 
 	ch := theReader.StartRead()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,8 @@ type AdvancedOptions struct {
 	TargetRedisProtoMaxBulkLen      uint64 `mapstructure:"target_redis_proto_max_bulk_len" default:"512000000"`
 
 	AwsPSync string `mapstructure:"aws_psync" default:""` // 10.0.0.1:6379@nmfu2sl5osync,10.0.0.1:6379@xhma21xfkssync
+
+	EmptyDBBeforeSync bool `mapstructure:"empty_db_before_sync" default:"false"`
 }
 
 type ModuleOptions struct {

--- a/internal/writer/interface.go
+++ b/internal/writer/interface.go
@@ -8,5 +8,6 @@ import (
 type Writer interface {
 	status.Statusable
 	Write(entry *entry.Entry)
+	Flush()
 	Close()
 }

--- a/internal/writer/redis_cluster_writer.go
+++ b/internal/writer/redis_cluster_writer.go
@@ -23,6 +23,12 @@ func NewRedisClusterWriter(opts *RedisWriterOptions) Writer {
 	return rw
 }
 
+func (r *RedisClusterWriter) Flush() {
+	for _, writer := range r.writers {
+		writer.Flush()
+	}
+}
+
 func (r *RedisClusterWriter) Close() {
 	for _, writer := range r.writers {
 		writer.Close()

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -48,6 +48,13 @@ func NewRedisStandaloneWriter(opts *RedisWriterOptions) Writer {
 	return rw
 }
 
+func (w *redisStandaloneWriter) Flush() {
+	reply := w.client.DoWithStringReply("FLUSHALL")
+	if reply != "OK" {
+		log.Panicf("flush failed with reply: %s", reply)
+	}
+}
+
 func (w *redisStandaloneWriter) Close() {
 	close(w.chWaitReply)
 	w.chWg.Wait()

--- a/shake.toml
+++ b/shake.toml
@@ -69,6 +69,12 @@ target_redis_proto_max_bulk_len = 512_000_000
 # If the source is Elasticache or MemoryDB, you can set this item.
 aws_psync = "" # example: aws_psync = "10.0.0.1:6379@nmfu2sl5osync,10.0.0.1:6379@xhma21xfkssync"
 
+# destination will delete itself entire database before fetching files
+# from source during full synchronization.
+# This option is similar redis replicas RDB diskless load option:
+#   repl-diskless-load on-empty-db
+empty_db_before_sync = false
+
 [module]
 # The data format for BF.LOADCHUNK is not compatible in different versions. v2.6.3 <=> 20603
 target_mbbloom_version = 20603


### PR DESCRIPTION
hi, 
大多数时候，我们希望源db和目的db的数据是一致的，
所以这个pr希望增加在同步之前清空目的db的功能，以保证目的db不会有遗留的脏数据