### PR TITLE
chore: Format the import order

### DIFF
--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "net/http/pprof"
+
 	"RedisShake/internal/config"
 	"RedisShake/internal/function"
 	"RedisShake/internal/log"
@@ -8,8 +10,8 @@ import (
 	"RedisShake/internal/status"
 	"RedisShake/internal/utils"
 	"RedisShake/internal/writer"
+
 	"github.com/mcuadros/go-defaults"
-	_ "net/http/pprof"
 )
 
 func main() {

--- a/internal/client/func.go
+++ b/internal/client/func.go
@@ -1,10 +1,11 @@
 package client
 
 import (
-	"RedisShake/internal/client/proto"
-	"RedisShake/internal/log"
 	"bytes"
 	"strings"
+
+	"RedisShake/internal/client/proto"
+	"RedisShake/internal/log"
 )
 
 func EncodeArgv(argv []string, buf *bytes.Buffer) {

--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -1,13 +1,14 @@
 package client
 
 import (
-	"RedisShake/internal/client/proto"
-	"RedisShake/internal/log"
 	"bufio"
 	"crypto/tls"
 	"net"
 	"strconv"
 	"time"
+
+	"RedisShake/internal/client/proto"
+	"RedisShake/internal/log"
 )
 
 type Redis struct {

--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -1,12 +1,13 @@
 package commands
 
 import (
-	"RedisShake/internal/log"
-	"RedisShake/internal/utils"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
+
+	"RedisShake/internal/log"
+	"RedisShake/internal/utils"
 )
 
 // CalcKeys https://redis.io/docs/reference/key-specs/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,15 @@
 package config
 
 import (
-	"RedisShake/internal/log"
 	"fmt"
+	"os"
+	"strings"
+
+	"RedisShake/internal/log"
+
 	"github.com/mcuadros/go-defaults"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
 )
 
 type AdvancedOptions struct {

--- a/internal/entry/entry.go
+++ b/internal/entry/entry.go
@@ -1,11 +1,12 @@
 package entry
 
 import (
+	"bytes"
+	"strings"
+
 	"RedisShake/internal/client/proto"
 	"RedisShake/internal/commands"
 	"RedisShake/internal/log"
-	"bytes"
-	"strings"
 )
 
 type Entry struct {

--- a/internal/function/function.go
+++ b/internal/function/function.go
@@ -1,11 +1,13 @@
 package function
 
 import (
+	"strings"
+
 	"RedisShake/internal/config"
 	"RedisShake/internal/entry"
 	"RedisShake/internal/log"
+
 	lua "github.com/yuin/gopher-lua"
-	"strings"
 )
 
 var luaString string

--- a/internal/log/func.go
+++ b/internal/log/func.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/go-stack/stack"
 	"os"
+
+	"github.com/go-stack/stack"
 )
 
 func Debugf(format string, args ...interface{}) {

--- a/internal/log/init.go
+++ b/internal/log/init.go
@@ -2,9 +2,10 @@ package log
 
 import (
 	"fmt"
-	"github.com/rs/zerolog"
 	"os"
 	"path/filepath"
+
+	"github.com/rs/zerolog"
 )
 
 var logger zerolog.Logger

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -1,12 +1,6 @@
 package rdb
 
 import (
-	"RedisShake/internal/config"
-	"RedisShake/internal/entry"
-	"RedisShake/internal/log"
-	"RedisShake/internal/rdb/structure"
-	"RedisShake/internal/rdb/types"
-	"RedisShake/internal/utils"
 	"bufio"
 	"bytes"
 	"encoding/binary"
@@ -14,6 +8,13 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"RedisShake/internal/config"
+	"RedisShake/internal/entry"
+	"RedisShake/internal/log"
+	"RedisShake/internal/rdb/structure"
+	"RedisShake/internal/rdb/types"
+	"RedisShake/internal/utils"
 )
 
 const (

--- a/internal/rdb/structure/byte.go
+++ b/internal/rdb/structure/byte.go
@@ -1,8 +1,9 @@
 package structure
 
 import (
-	"RedisShake/internal/log"
 	"io"
+
+	"RedisShake/internal/log"
 )
 
 func ReadByte(rd io.Reader) byte {

--- a/internal/rdb/structure/float.go
+++ b/internal/rdb/structure/float.go
@@ -1,11 +1,12 @@
 package structure
 
 import (
-	"RedisShake/internal/log"
 	"encoding/binary"
 	"io"
 	"math"
 	"strconv"
+
+	"RedisShake/internal/log"
 )
 
 func ReadFloat(rd io.Reader) float64 {

--- a/internal/rdb/structure/length.go
+++ b/internal/rdb/structure/length.go
@@ -1,10 +1,11 @@
 package structure
 
 import (
-	"RedisShake/internal/log"
 	"encoding/binary"
 	"fmt"
 	"io"
+
+	"RedisShake/internal/log"
 )
 
 const (

--- a/internal/rdb/structure/listpack.go
+++ b/internal/rdb/structure/listpack.go
@@ -1,12 +1,13 @@
 package structure
 
 import (
-	"RedisShake/internal/log"
 	"bufio"
 	"io"
 	"math"
 	"strconv"
 	"strings"
+
+	"RedisShake/internal/log"
 )
 
 const (

--- a/internal/rdb/structure/string.go
+++ b/internal/rdb/structure/string.go
@@ -1,9 +1,10 @@
 package structure
 
 import (
-	"RedisShake/internal/log"
 	"io"
 	"strconv"
+
+	"RedisShake/internal/log"
 )
 
 const (

--- a/internal/rdb/structure/ziplist.go
+++ b/internal/rdb/structure/ziplist.go
@@ -1,12 +1,13 @@
 package structure
 
 import (
-	"RedisShake/internal/log"
 	"bufio"
 	"encoding/binary"
 	"io"
 	"strconv"
 	"strings"
+
+	"RedisShake/internal/log"
 )
 
 const (

--- a/internal/rdb/types/hash.go
+++ b/internal/rdb/types/hash.go
@@ -1,9 +1,10 @@
 package types
 
 import (
+	"io"
+
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb/structure"
-	"io"
 )
 
 type HashObject struct {

--- a/internal/rdb/types/interface.go
+++ b/internal/rdb/types/interface.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"RedisShake/internal/log"
 	"io"
+
+	"RedisShake/internal/log"
 )
 
 const (

--- a/internal/rdb/types/list.go
+++ b/internal/rdb/types/list.go
@@ -1,9 +1,10 @@
 package types
 
 import (
+	"io"
+
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb/structure"
-	"io"
 )
 
 // quicklist node container formats

--- a/internal/rdb/types/mbbloom.go
+++ b/internal/rdb/types/mbbloom.go
@@ -1,11 +1,12 @@
 package types
 
 import (
-	"RedisShake/internal/config"
-	"RedisShake/internal/rdb/structure"
 	"io"
 	"strconv"
 	"unsafe"
+
+	"RedisShake/internal/config"
+	"RedisShake/internal/rdb/structure"
 )
 
 // BloomObject for MBbloom-- at https://github.com/RedisBloom/RedisBloom

--- a/internal/rdb/types/set.go
+++ b/internal/rdb/types/set.go
@@ -1,9 +1,10 @@
 package types
 
 import (
+	"io"
+
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb/structure"
-	"io"
 )
 
 type SetObject struct {

--- a/internal/rdb/types/stream.go
+++ b/internal/rdb/types/stream.go
@@ -1,12 +1,13 @@
 package types
 
 import (
-	"RedisShake/internal/log"
-	"RedisShake/internal/rdb/structure"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"strconv"
+
+	"RedisShake/internal/log"
+	"RedisShake/internal/rdb/structure"
 )
 
 /*

--- a/internal/rdb/types/string.go
+++ b/internal/rdb/types/string.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"RedisShake/internal/rdb/structure"
 	"io"
+
+	"RedisShake/internal/rdb/structure"
 )
 
 type StringObject struct {

--- a/internal/rdb/types/zset.go
+++ b/internal/rdb/types/zset.go
@@ -1,10 +1,11 @@
 package types
 
 import (
-	"RedisShake/internal/log"
-	"RedisShake/internal/rdb/structure"
 	"fmt"
 	"io"
+
+	"RedisShake/internal/log"
+	"RedisShake/internal/rdb/structure"
 )
 
 type ZSetEntry struct {

--- a/internal/reader/aof_reader.go
+++ b/internal/reader/aof_reader.go
@@ -1,8 +1,9 @@
 package reader
 
 import (
-	"RedisShake/internal/aof"
 	"path/filepath"
+
+	"RedisShake/internal/aof"
 
 	"RedisShake/internal/entry"
 	"RedisShake/internal/log"

--- a/internal/reader/parsing_aof.go
+++ b/internal/reader/parsing_aof.go
@@ -1,9 +1,6 @@
 package reader
 
 import (
-	"RedisShake/internal/aof"
-	"RedisShake/internal/entry"
-	"RedisShake/internal/log"
 	"bufio"
 	"bytes"
 	"container/list"
@@ -16,6 +13,10 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"RedisShake/internal/aof"
+	"RedisShake/internal/entry"
+	"RedisShake/internal/log"
 )
 
 const (

--- a/internal/reader/rdb_reader.go
+++ b/internal/reader/rdb_reader.go
@@ -1,11 +1,13 @@
 package reader
 
 import (
+	"fmt"
+
 	"RedisShake/internal/entry"
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb"
 	"RedisShake/internal/utils"
-	"fmt"
+
 	"github.com/dustin/go-humanize"
 )
 

--- a/internal/reader/scan_cluster_reader.go
+++ b/internal/reader/scan_cluster_reader.go
@@ -1,10 +1,11 @@
 package reader
 
 import (
-	"RedisShake/internal/entry"
-	"RedisShake/internal/utils"
 	"fmt"
 	"sync"
+
+	"RedisShake/internal/entry"
+	"RedisShake/internal/utils"
 )
 
 type scanClusterReader struct {

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -1,6 +1,12 @@
 package reader
 
 import (
+	"fmt"
+	"math/bits"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"RedisShake/internal/client"
 	"RedisShake/internal/client/proto"
 	"RedisShake/internal/config"
@@ -8,11 +14,6 @@ import (
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb/types"
 	"RedisShake/internal/utils"
-	"fmt"
-	"math/bits"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 type ScanReaderOptions struct {

--- a/internal/reader/sync_cluster_reader.go
+++ b/internal/reader/sync_cluster_reader.go
@@ -1,11 +1,12 @@
 package reader
 
 import (
+	"fmt"
+	"sync"
+
 	"RedisShake/internal/entry"
 	"RedisShake/internal/log"
 	"RedisShake/internal/utils"
-	"fmt"
-	"sync"
 )
 
 type syncClusterReader struct {

--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -1,6 +1,15 @@
 package reader
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"RedisShake/internal/client"
 	"RedisShake/internal/config"
 	"RedisShake/internal/entry"
@@ -8,15 +17,8 @@ import (
 	"RedisShake/internal/rdb"
 	"RedisShake/internal/utils"
 	"RedisShake/internal/utils/file_rotate"
-	"bufio"
-	"fmt"
+
 	"github.com/dustin/go-humanize"
-	"io"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type SyncReaderOptions struct {

--- a/internal/status/handler.go
+++ b/internal/status/handler.go
@@ -1,12 +1,13 @@
 package status
 
 import (
-	"RedisShake/internal/config"
-	"RedisShake/internal/log"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"RedisShake/internal/config"
+	"RedisShake/internal/log"
 )
 
 func Handler(w http.ResponseWriter, _ *http.Request) {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,9 +1,10 @@
 package status
 
 import (
+	"time"
+
 	"RedisShake/internal/config"
 	"RedisShake/internal/log"
-	"time"
 )
 
 type Statusable interface {

--- a/internal/utils/cluster_nodes.go
+++ b/internal/utils/cluster_nodes.go
@@ -1,11 +1,12 @@
 package utils
 
 import (
-	"RedisShake/internal/client"
-	"RedisShake/internal/log"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"RedisShake/internal/client"
+	"RedisShake/internal/log"
 )
 
 func GetRedisClusterNodes(address string, username string, password string, Tls bool) (addresses []string, slots [][]int) {

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"RedisShake/internal/log"
 	"os"
 	"path/filepath"
+
+	"RedisShake/internal/log"
 )
 
 func CreateEmptyDir(dir string) {

--- a/internal/utils/file_rotate/aof_reader.go
+++ b/internal/utils/file_rotate/aof_reader.go
@@ -1,12 +1,13 @@
 package rotate
 
 import (
-	"RedisShake/internal/log"
-	"RedisShake/internal/utils"
 	"fmt"
 	"io"
 	"os"
 	"time"
+
+	"RedisShake/internal/log"
+	"RedisShake/internal/utils"
 )
 
 type AOFReader struct {

--- a/internal/utils/file_rotate/aof_writer.go
+++ b/internal/utils/file_rotate/aof_writer.go
@@ -1,9 +1,10 @@
 package rotate
 
 import (
-	"RedisShake/internal/log"
 	"fmt"
 	"os"
+
+	"RedisShake/internal/log"
 )
 
 const MaxFileSize = 1024 * 1024 * 1024 // 1G

--- a/internal/utils/filelock.go
+++ b/internal/utils/filelock.go
@@ -1,11 +1,13 @@
 package utils
 
 import (
-	"RedisShake/internal/config"
-	"RedisShake/internal/log"
-	"github.com/theckman/go-flock"
 	"os"
 	"path/filepath"
+
+	"RedisShake/internal/config"
+	"RedisShake/internal/log"
+
+	"github.com/theckman/go-flock"
 )
 
 var filelock *flock.Flock

--- a/internal/utils/ncpu.go
+++ b/internal/utils/ncpu.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
+	"runtime"
+
 	"RedisShake/internal/config"
 	"RedisShake/internal/log"
-	"runtime"
 )
 
 func SetNcpu() {

--- a/internal/utils/pprof.go
+++ b/internal/utils/pprof.go
@@ -1,10 +1,11 @@
 package utils
 
 import (
-	"RedisShake/internal/config"
-	"RedisShake/internal/log"
 	"fmt"
 	"net/http"
+
+	"RedisShake/internal/config"
+	"RedisShake/internal/log"
 )
 
 func SetPprofPort() {

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -1,17 +1,18 @@
 package writer
 
 import (
-	"RedisShake/internal/client"
-	"RedisShake/internal/client/proto"
-	"RedisShake/internal/config"
-	"RedisShake/internal/entry"
-	"RedisShake/internal/log"
 	"fmt"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"RedisShake/internal/client"
+	"RedisShake/internal/client/proto"
+	"RedisShake/internal/config"
+	"RedisShake/internal/entry"
+	"RedisShake/internal/log"
 )
 
 type RedisWriterOptions struct {


### PR DESCRIPTION
This is the first step to refactor the RedisShake codebase. I will fix the code style first

About the import order, I recommend to following the goimports style