### PR TITLE
bugfix: Fix cluster nodes parsing error

### DIFF
--- a/internal/utils/cluster_nodes.go
+++ b/internal/utils/cluster_nodes.go
@@ -75,8 +75,8 @@ func GetRedisClusterNodes(address string, username string, password string, Tls 
 				slot = append(slot, j)
 				slotsCount++
 			}
-			slots = append(slots, slot)
 		}
+		slots = append(slots, slot)
 	}
 	if slotsCount != 16384 {
 		log.Panicf("invalid cluster nodes slots. slots_count=%v, address=%v", slotsCount, address)

--- a/internal/utils/cluster_nodes.go
+++ b/internal/utils/cluster_nodes.go
@@ -46,6 +46,12 @@ func GetRedisClusterNodes(address string, username string, password string, Tls 
 		slot := make([]int, 0)
 		for i := 8; i < len(words); i++ {
 			words[i] = strings.TrimSpace(words[i])
+			if strings.HasPrefix(words[i], "[") {
+				// issue: https://github.com/tair-opensource/RedisShake/issues/730
+				// [****] appear at the end of each line of "cluster nodes",
+				// indicating data migration between nodes is in progress.
+				break
+			}
 			var start, end int
 			var err error
 			if strings.Contains(words[i], "-") {


### PR DESCRIPTION
1. 集群节点迁移时的解析错误：https://github.com/tair-opensource/RedisShake/issues/730
2. 当节点所属的 slot 不是连续时解析存在问题：https://github.com/tair-opensource/RedisShake/issues/689