### PR TITLE
feature: Add parallel writer support

### DIFF
--- a/internal/function/function.go
+++ b/internal/function/function.go
@@ -21,6 +21,10 @@ func Init() {
 	}
 }
 
+func IsFunctionEnabled() bool {
+	return len(luaString) != 0
+}
+
 // DB
 // GROUP
 // CMD

--- a/internal/reader/aof_reader.go
+++ b/internal/reader/aof_reader.go
@@ -66,7 +66,7 @@ func NewAOFReader(opts *AOFReaderOptions) Reader {
 	return r
 }
 
-func (r *aofReader) StartRead() chan *entry.Entry {
+func (r *aofReader) StartRead() []chan *entry.Entry {
 	//init entry
 	r.ch = make(chan *entry.Entry, 1024)
 
@@ -101,5 +101,5 @@ func (r *aofReader) StartRead() chan *entry.Entry {
 
 	}()
 
-	return r.ch
+	return []chan *entry.Entry{r.ch}
 }

--- a/internal/reader/interface.go
+++ b/internal/reader/interface.go
@@ -7,5 +7,5 @@ import (
 
 type Reader interface {
 	status.Statusable
-	StartRead() chan *entry.Entry
+	StartRead() []chan *entry.Entry
 }

--- a/internal/reader/rdb_reader.go
+++ b/internal/reader/rdb_reader.go
@@ -41,7 +41,7 @@ func NewRDBReader(opts *RdbReaderOptions) Reader {
 	return r
 }
 
-func (r *rdbReader) StartRead() chan *entry.Entry {
+func (r *rdbReader) StartRead() []chan *entry.Entry {
 	log.Infof("[%s] start read", r.stat.Name)
 	r.ch = make(chan *entry.Entry, 1024)
 	updateFunc := func(offset int64) {
@@ -58,7 +58,7 @@ func (r *rdbReader) StartRead() chan *entry.Entry {
 		close(r.ch)
 	}()
 
-	return r.ch
+	return []chan *entry.Entry{r.ch}
 }
 
 func (r *rdbReader) Status() interface{} {

--- a/internal/reader/scan_cluster_reader.go
+++ b/internal/reader/scan_cluster_reader.go
@@ -1,11 +1,9 @@
 package reader
 
 import (
-	"fmt"
-	"sync"
-
 	"RedisShake/internal/entry"
 	"RedisShake/internal/utils"
+	"fmt"
 )
 
 type scanClusterReader struct {
@@ -25,23 +23,12 @@ func NewScanClusterReader(opts *ScanReaderOptions) Reader {
 	return rd
 }
 
-func (rd *scanClusterReader) StartRead() chan *entry.Entry {
-	ch := make(chan *entry.Entry, 1024)
-	var wg sync.WaitGroup
+func (rd *scanClusterReader) StartRead() []chan *entry.Entry {
+	channels := make([]chan *entry.Entry, 0)
 	for _, r := range rd.readers {
-		wg.Add(1)
-		go func(r Reader) {
-			for e := range r.StartRead() {
-				ch <- e
-			}
-			wg.Done()
-		}(r)
+		channels = append(channels, r.StartRead()...)
 	}
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-	return ch
+	return channels
 }
 
 func (rd *scanClusterReader) Status() interface{} {

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -67,11 +67,11 @@ func NewScanStandaloneReader(opts *ScanReaderOptions) Reader {
 	return r
 }
 
-func (r *scanStandaloneReader) StartRead() chan *entry.Entry {
+func (r *scanStandaloneReader) StartRead() []chan *entry.Entry {
 	r.subscript()
 	go r.scan()
 	go r.fetch()
-	return r.ch
+	return []chan *entry.Entry{r.ch}
 }
 
 func (r *scanStandaloneReader) subscript() {

--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -87,7 +87,7 @@ func NewSyncStandaloneReader(opts *SyncReaderOptions) Reader {
 	return r
 }
 
-func (r *syncStandaloneReader) StartRead() chan *entry.Entry {
+func (r *syncStandaloneReader) StartRead() []chan *entry.Entry {
 	r.ch = make(chan *entry.Entry, 1024)
 	go func() {
 		r.sendReplconfListenPort()
@@ -106,7 +106,7 @@ func (r *syncStandaloneReader) StartRead() chan *entry.Entry {
 		close(r.ch)
 	}()
 
-	return r.ch
+	return []chan *entry.Entry{r.ch}
 }
 
 func (r *syncStandaloneReader) sendReplconfListenPort() {


### PR DESCRIPTION
shake 运行环境：
* ecs.c8i.4xlarge(Intel(R) Xeon(R) Platinum 8475B)
* 云盘、网络均不构成瓶颈

测试 Redis 均为阿里云云数据库 Redis 云原生版。

---


源端为 Redis 7.0 集群，64 分片
* 目的端为 Redis 7.0 单实例，ops 为 280k
* 目的端为 Redis 7.0 集群，64 分片，ops 为 300k

从上述可以看出，理论上的 Redis 7.0 集群的写性能应该可以做到 280*64k，但受限于代码实例没有做到。

应用此 PR 后：
* 目的端为 Redis 7.0 集群，64 分片，ops 为 600k

提升不明显，且此修改较丑不准备合入。

---

在高 ops 场景下代码中有多处均构成瓶颈，无法通过简单修改实现。