### PR TITLE
refactor: Refacotr the calls of flushall command

### DIFF
--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -96,13 +96,10 @@ func main() {
 			log.Infof("create RedisStandaloneWriter: %v", opts.Address)
 		}
 		if config.Opt.Advanced.EmptyDBBeforeSync {
-			if opts.OffReply {
-				entry := entry.NewEntry()
-				entry.Argv = []string{"FLUSHALL"}
-				theWriter.Write(entry)
-			} else {
-				theWriter.Flush()
-			}
+			// exec FLUSHALL command to flush db
+			entry := entry.NewEntry()
+			entry.Argv = []string{"FLUSHALL"}
+			theWriter.Write(entry)
 		}
 	} else {
 		log.Panicf("no writer config entry found")

--- a/internal/writer/interface.go
+++ b/internal/writer/interface.go
@@ -8,6 +8,5 @@ import (
 type Writer interface {
 	status.Statusable
 	Write(entry *entry.Entry)
-	Flush()
 	Close()
 }

--- a/internal/writer/redis_cluster_writer.go
+++ b/internal/writer/redis_cluster_writer.go
@@ -23,12 +23,6 @@ func NewRedisClusterWriter(opts *RedisWriterOptions) Writer {
 	return rw
 }
 
-func (r *RedisClusterWriter) Flush() {
-	for _, writer := range r.writers {
-		writer.Flush()
-	}
-}
-
 func (r *RedisClusterWriter) Close() {
 	for _, writer := range r.writers {
 		writer.Close()

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -57,13 +57,6 @@ func NewRedisStandaloneWriter(opts *RedisWriterOptions) Writer {
 	return rw
 }
 
-func (w *redisStandaloneWriter) Flush() {
-	reply := w.client.DoWithStringReply("FLUSHALL")
-	if reply != "OK" {
-		log.Panicf("flush failed with reply: %s", reply)
-	}
-}
-
 func (w *redisStandaloneWriter) Close() {
 	if !w.offReply {
 		close(w.chWaitReply)


### PR DESCRIPTION
1. remove unnecessary method of Writer interface
2. use `Write` method to exec `flushall` command