### PR TITLE
feat: Support increment sync

### DIFF
--- a/internal/utils/file_rotate/aof_reader.go
+++ b/internal/utils/file_rotate/aof_reader.go
@@ -23,23 +23,23 @@ func NewAOFReader(name string, dir string, offset int64) *AOFReader {
 	r := new(AOFReader)
 	r.name = name
 	r.dir = dir
-	r.openFile(offset)
+	r.offset = offset
+	r.openFile()
 	return r
 }
 
-func (r *AOFReader) openFile(offset int64) {
+func (r *AOFReader) openFile() {
 	r.filepath = fmt.Sprintf("%s/%d.aof", r.dir, r.offset)
 	var err error
 	r.file, err = os.OpenFile(r.filepath, os.O_RDONLY, 0644)
 	if err != nil {
 		log.Panicf(err.Error())
 	}
-	r.offset = offset
 	r.pos = 0
 	log.Debugf("[%s] open file for read. filename=[%s]", r.name, r.filepath)
 }
 
-func (r *AOFReader) readNextFile(offset int64) {
+func (r *AOFReader) readNextFile() {
 	filepath := fmt.Sprintf("%s/%d.aof", r.dir, r.offset)
 	if utils.IsExist(filepath) {
 		r.Close()
@@ -47,7 +47,7 @@ func (r *AOFReader) readNextFile(offset int64) {
 		if err != nil {
 			return
 		}
-		r.openFile(offset)
+		r.openFile()
 	}
 }
 
@@ -55,7 +55,7 @@ func (r *AOFReader) Read(buf []byte) (n int, err error) {
 	n, err = r.file.Read(buf)
 	for err == io.EOF {
 		if r.filepath != fmt.Sprintf("%s/%d.aof", r.dir, r.offset) {
-			r.readNextFile(r.offset)
+			r.readNextFile()
 		}
 		time.Sleep(time.Millisecond * 10)
 		_, err = r.file.Seek(0, 1)

--- a/internal/utils/file_rotate/aof_writer.go
+++ b/internal/utils/file_rotate/aof_writer.go
@@ -23,18 +23,18 @@ func NewAOFWriter(name string, dir string, offset int64) *AOFWriter {
 	w := new(AOFWriter)
 	w.name = name
 	w.dir = dir
-	w.openFile(offset)
+	w.offset = offset
+	w.openFile()
 	return w
 }
 
-func (w *AOFWriter) openFile(offset int64) {
+func (w *AOFWriter) openFile() {
 	w.filepath = fmt.Sprintf("%s/%d.aof", w.dir, w.offset)
 	var err error
 	w.file, err = os.OpenFile(w.filepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		log.Panicf(err.Error())
 	}
-	w.offset = offset
 	w.filesize = 0
 	log.Debugf("[%s] open file for write. filename=[%s]", w.name, w.filepath)
 }
@@ -48,7 +48,7 @@ func (w *AOFWriter) Write(buf []byte) {
 	w.filesize += int64(len(buf))
 	if w.filesize > MaxFileSize {
 		w.Close()
-		w.openFile(w.offset)
+		w.openFile()
 	}
 	err = w.file.Sync()
 	if err != nil {


### PR DESCRIPTION
for issue #722 

通过sync_reader同步时，支持增量同步，避免每次都进行不必要的全量同步
以允许在shake短暂中断或重启后，可以从上次同步的offset处继续进行

1. 在连接源redis实例时，通过`info replication`命令获取`master_replid`字段
2. 修改保存aof的文件名，以接收到的起始offset作为文件名。在重启时可通过 `文件名 + 文件大小` 的方式得到上次同步的offset
3. 若能拿到上次同步的offset 且 `sync_rdb=false`，尝试进行增量同步，替换 `PSYNC ? -1`