### PR TITLE
refactor: send commands in pipeline

### DIFF
--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -92,7 +92,18 @@ func (r *Redis) Send(args ...string) {
 	if err != nil {
 		log.Panicf(err.Error())
 	}
-	r.flush()
+	r.Flush()
+}
+
+func (r *Redis) SendToBuffer(args ...string) {
+	argsInterface := make([]interface{}, len(args))
+	for inx, item := range args {
+		argsInterface[inx] = item
+	}
+	err := r.protoWriter.WriteArgs(argsInterface)
+	if err != nil {
+		log.Panicf(err.Error())
+	}
 }
 
 func (r *Redis) SendBytes(buf []byte) {
@@ -100,10 +111,17 @@ func (r *Redis) SendBytes(buf []byte) {
 	if err != nil {
 		log.Panicf(err.Error())
 	}
-	r.flush()
+	r.Flush()
 }
 
-func (r *Redis) flush() {
+func (r *Redis) SendBytesToBuffer(buf []byte) {
+	_, err := r.writer.Write(buf)
+	if err != nil {
+		log.Panicf(err.Error())
+	}
+}
+
+func (r *Redis) Flush() {
 	err := r.writer.Flush()
 	if err != nil {
 		log.Panicf(err.Error())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ type AdvancedOptions struct {
 	// ignore:  redis-shake will skip restore the key when meet "Target key name is busy" error.
 	RDBRestoreCommandBehavior string `mapstructure:"rdb_restore_command_behavior" default:"panic"`
 
-	PipelineCountLimit              uint64 `mapstructure:"pipeline_count_limit" default:"1024"`
+	PipelineCountLimit              uint32 `mapstructure:"pipeline_count_limit" default:"1024"`
 	TargetRedisClientMaxQuerybufLen int64  `mapstructure:"target_redis_client_max_querybuf_len" default:"1024000000"`
 	TargetRedisProtoMaxBulkLen      uint64 `mapstructure:"target_redis_proto_max_bulk_len" default:"512000000"`
 


### PR DESCRIPTION
As memtioned at https://github.com/tair-opensource/RedisShake/issues/735#issuecomment-1867447683

Currently the `pipeline_count_limit` field is the number of commands `in flight`,  not the [redis pipeling](https://redis.io/docs/manual/pipelining/)