### PR TITLE
bugfix: fix panic when sync reader needed to exit

### DIFF
--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -108,7 +108,6 @@ func (r *syncStandaloneReader) StartRead(ctx context.Context) chan *entry.Entry 
 			r.sendAOF(startOffset)
 		}
 		close(r.ch)
-		r.client.Close()
 	}()
 
 	return r.ch


### PR DESCRIPTION
之前的sync读部分新增了优雅退出部分，但是存在一些缺陷，具体如下：

复现流程一：
1. sync模式配置开启RDB同步、关闭AOF同步
2. 在某个协程RDB同步完成时，会直接关闭reader client，导致协程里读到关闭的连接引发panic。

复现流程二：
1. sync模式配置开启RDB同步
2. 发送信号触发优雅退出，会直接关闭reader client，导致协程里读到关闭的连接引发panic。

由于集群模式下是多协程同步，一个协程引发panic会导致其余协程存在数据同步不完全的问题，需要修复一下。