### PR TITLE
perf(rdb): parse rdb use less memeory

### DIFF
--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -28,7 +28,7 @@ func main() {
 	utils.SetPprofPort()
 	luaRuntime := function.New(config.Opt.Function)
 
-  ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// create reader

--- a/internal/rdb/types/interface.go
+++ b/internal/rdb/types/interface.go
@@ -64,7 +64,7 @@ type RedisCmd []string
 // RedisObject is interface for a redis object
 type RedisObject interface {
 	LoadFromBuffer(rd io.Reader, key string, typeByte byte)
-	Rewrite() []RedisCmd
+	Rewrite() <-chan RedisCmd
 }
 
 func ParseObject(rd io.Reader, typeByte byte, key string) RedisObject {

--- a/internal/rdb/types/set_test.go
+++ b/internal/rdb/types/set_test.go
@@ -16,16 +16,21 @@ func testOne(t *testing.T, typeByte byte, setData string, values []string) {
 	}
 	o := new(SetObject)
 	o.LoadFromBuffer(bytes.NewReader([]byte(setData[1:])), "key", typeByte)
-	if len(o.elements) != len(values) {
-		t.Errorf("elements not match. len(o.elements)=[%d], len(values)=[%d]", len(o.elements), len(values))
+	cmdC := o.Rewrite()
+	var elements []string
+	for cmd := range cmdC {
+		elements = append(elements, cmd[2])
 	}
-	count := len(o.elements)
-	sort.Strings(o.elements)
+	if len(elements) != len(values) {
+		t.Errorf("elements not match. len(o.elements)=[%d], len(values)=[%d]", len(elements), len(values))
+	}
+	count := len(elements)
+	sort.Strings(elements)
 	sort.Strings(values)
 	// check set
 	for i := 0; i < count; i++ {
-		if o.elements[i] != values[i] {
-			t.Errorf("elements not match. o.elements[i]=[%s], values[i]=[%s]", o.elements[i], values[i])
+		if elements[i] != values[i] {
+			t.Errorf("elements not match. o.elements[i]=[%s], values[i]=[%s]", elements[i], values[i])
 		}
 	}
 }

--- a/internal/rdb/types/tairhash.go
+++ b/internal/rdb/types/tairhash.go
@@ -17,6 +17,7 @@ type TairHashObject struct {
 func (o *TairHashObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
 	o.dictSize = structure.ReadModuleUnsigned(rd)
 	o.key = structure.ReadModuleString(rd)
+	o.rd = rd
 	o.cmdC = make(chan RedisCmd)
 }
 

--- a/internal/rdb/types/tairhash.go
+++ b/internal/rdb/types/tairhash.go
@@ -7,51 +7,40 @@ import (
 	"RedisShake/internal/rdb/structure"
 )
 
-type TairHashValue struct {
-	skey       string
-	version    string
-	expire     string
-	fieldValue string
-}
-
 type TairHashObject struct {
 	dictSize string
 	key      string
-	value    []TairHashValue
+	rd       io.Reader
+	cmdC     chan RedisCmd
 }
 
 func (o *TairHashObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
 	o.dictSize = structure.ReadModuleUnsigned(rd)
 	o.key = structure.ReadModuleString(rd)
-
-	size, _ := strconv.Atoi(o.dictSize)
-	for i := 0; i < size; i++ {
-		hashValue := TairHashValue{
-			structure.ReadModuleString(rd),
-			structure.ReadModuleUnsigned(rd),
-			structure.ReadModuleUnsigned(rd),
-			structure.ReadModuleString(rd),
-		}
-		o.value = append(o.value, hashValue)
-	}
-	structure.ReadModuleEof(rd)
+	o.cmdC = make(chan RedisCmd)
 }
 
-func (o *TairHashObject) Rewrite() []RedisCmd {
-	var cmds []RedisCmd
-	size, _ := strconv.Atoi(o.dictSize)
-	for i := 0; i < size; i++ {
-		cmd := []string{}
-		expire, _ := strconv.Atoi(o.value[i].expire)
-		if expire == 0 {
-			cmd = append(cmd, "EXHSET", o.key, o.value[i].skey, o.value[i].fieldValue)
-		} else {
-			cmd = append(cmd, "EXHSET", o.key, o.value[i].skey, o.value[i].fieldValue,
-				"ABS", o.value[i].version,
-				"PXAT", o.value[i].expire)
+func (o *TairHashObject) Rewrite() <-chan RedisCmd {
+	rd := o.rd
+	cmdC := o.cmdC
+	go func() {
+		defer close(o.cmdC)
+		size, _ := strconv.Atoi(o.dictSize)
+		for i := 0; i < size; i++ {
+			skey := structure.ReadModuleString(rd)
+			version := structure.ReadModuleUnsigned(rd)
+			expireText := structure.ReadModuleUnsigned(rd)
+			fieldValue := structure.ReadModuleString(rd)
+			expire, _ := strconv.Atoi(expireText)
+			if expire == 0 {
+				cmdC <- RedisCmd{"EXHSET", o.key, skey, fieldValue}
+			} else {
+				cmdC <- RedisCmd{"EXHSET", o.key, skey, fieldValue,
+					"ABS", version,
+					"PXAT", expireText}
+			}
 		}
-
-		cmds = append(cmds, cmd)
-	}
-	return cmds
+		structure.ReadModuleEof(rd)
+	}()
+	return cmdC
 }

--- a/internal/rdb/types/tairstring.go
+++ b/internal/rdb/types/tairstring.go
@@ -1,32 +1,31 @@
 package types
 
 import (
-	"io"
-
 	"RedisShake/internal/rdb/structure"
+	"io"
 )
 
-type TairStringValue struct {
-	version   string
-	flags     string
-	tairValue string
-}
-
 type TairStringObject struct {
-	value TairStringValue
-	key   string
+	key  string
+	rd   io.Reader
+	cmdC chan RedisCmd
 }
 
 func (o *TairStringObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
 	o.key = key
-	o.value.version = structure.ReadModuleUnsigned(rd)
-	o.value.flags = structure.ReadModuleUnsigned(rd)
-	o.value.tairValue = structure.ReadModuleString(rd)
-	structure.ReadModuleEof(rd)
+	o.rd = rd
+	o.cmdC = make(chan RedisCmd)
 }
 
-func (o *TairStringObject) Rewrite() []RedisCmd {
-	cmd := RedisCmd{}
-	cmd = append(cmd, "EXSET", o.key, o.value.tairValue, "ABS", o.value.version, "FLAGS", o.value.flags)
-	return []RedisCmd{cmd}
+func (o *TairStringObject) Rewrite() <-chan RedisCmd {
+	go func() {
+		defer close(o.cmdC)
+		rd := o.rd
+		version := structure.ReadModuleUnsigned(rd)
+		flags := structure.ReadModuleUnsigned(rd)
+		tairValue := structure.ReadModuleString(rd)
+		structure.ReadModuleEof(rd)
+		o.cmdC <- RedisCmd{"EXSET", o.key, tairValue, "ABS", version, "FLAGS", flags}
+	}()
+	return o.cmdC
 }

--- a/internal/rdb/types/tairzset.go
+++ b/internal/rdb/types/tairzset.go
@@ -12,35 +12,34 @@ type TairZsetObject struct {
 	key      string
 	length   string
 	scoreNum string
-	value    map[string][]string
+	rd       io.Reader
+	cmdC     chan RedisCmd
 }
 
 func (o *TairZsetObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
 	o.key = key
 	o.length = structure.ReadModuleUnsigned(rd)
 	o.scoreNum = structure.ReadModuleUnsigned(rd)
-
-	len, _ := strconv.Atoi(o.length)
-	scoreNum, _ := strconv.Atoi(o.scoreNum)
-	valueMap := make(map[string][]string)
-	for i := 0; i < len; i++ {
-		key := structure.ReadModuleString(rd)
-		values := []string{}
-		for j := 0; j < scoreNum; j++ {
-			values = append(values, structure.ReadModuleDouble(rd))
-		}
-		valueMap[key] = values
-	}
-	o.value = valueMap
-	structure.ReadModuleEof(rd)
+	o.cmdC = make(chan RedisCmd)
 }
 
-func (o *TairZsetObject) Rewrite() []RedisCmd {
-	var cmds []RedisCmd
-	for k, v := range o.value {
-		score := strings.Join(v, "#")
-		cmd := RedisCmd{"EXZADD", o.key, score, k}
-		cmds = append(cmds, cmd)
-	}
-	return cmds
+func (o *TairZsetObject) Rewrite() <-chan RedisCmd {
+	rd := o.rd
+	cmdC := o.cmdC
+	go func() {
+		defer close(cmdC)
+		length, _ := strconv.Atoi(o.length)
+		scoreNum, _ := strconv.Atoi(o.scoreNum)
+		for i := 0; i < length; i++ {
+			key := structure.ReadModuleString(rd)
+			var values []string
+			for j := 0; j < scoreNum; j++ {
+				values = append(values, structure.ReadModuleDouble(rd))
+			}
+			score := strings.Join(values, "#")
+			cmdC <- RedisCmd{"EXZADD", o.key, score, key}
+		}
+		structure.ReadModuleEof(rd)
+	}()
+	return cmdC
 }

--- a/internal/rdb/types/tairzset.go
+++ b/internal/rdb/types/tairzset.go
@@ -9,17 +9,13 @@ import (
 )
 
 type TairZsetObject struct {
-	key      string
-	length   string
-	scoreNum string
-	rd       io.Reader
-	cmdC     chan RedisCmd
+	key  string
+	rd   io.Reader
+	cmdC chan RedisCmd
 }
 
 func (o *TairZsetObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
 	o.key = key
-	o.length = structure.ReadModuleUnsigned(rd)
-	o.scoreNum = structure.ReadModuleUnsigned(rd)
 	o.rd = rd
 	o.cmdC = make(chan RedisCmd)
 }
@@ -29,8 +25,8 @@ func (o *TairZsetObject) Rewrite() <-chan RedisCmd {
 	cmdC := o.cmdC
 	go func() {
 		defer close(cmdC)
-		length, _ := strconv.Atoi(o.length)
-		scoreNum, _ := strconv.Atoi(o.scoreNum)
+		length, _ := strconv.Atoi(structure.ReadModuleUnsigned(rd))
+		scoreNum, _ := strconv.Atoi(structure.ReadModuleUnsigned(rd))
 		for i := 0; i < length; i++ {
 			key := structure.ReadModuleString(rd)
 			var values []string

--- a/internal/rdb/types/tairzset.go
+++ b/internal/rdb/types/tairzset.go
@@ -20,6 +20,7 @@ func (o *TairZsetObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte)
 	o.key = key
 	o.length = structure.ReadModuleUnsigned(rd)
 	o.scoreNum = structure.ReadModuleUnsigned(rd)
+	o.rd = rd
 	o.cmdC = make(chan RedisCmd)
 }
 

--- a/internal/rdb/types/zset.go
+++ b/internal/rdb/types/zset.go
@@ -8,83 +8,83 @@ import (
 	"RedisShake/internal/rdb/structure"
 )
 
-type ZSetEntry struct {
-	Member string
-	Score  string
-}
-
 type ZsetObject struct {
 	key      string
-	elements []ZSetEntry
+	typeByte byte
+	rd       io.Reader
+	cmdC     chan RedisCmd
 }
 
 func (o *ZsetObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
 	o.key = key
-	switch typeByte {
-	case rdbTypeZSet:
-		o.readZset(rd)
-	case rdbTypeZSet2:
-		o.readZset2(rd)
-	case rdbTypeZSetZiplist:
-		o.readZsetZiplist(rd)
-	case rdbTypeZSetListpack:
-		o.readZsetListpack(rd)
-	default:
-		log.Panicf("unknown zset type. typeByte=[%d]", typeByte)
-	}
+	o.typeByte = typeByte
+	o.rd = rd
+	o.cmdC = make(chan RedisCmd)
 }
 
-func (o *ZsetObject) readZset(rd io.Reader) {
+func (o *ZsetObject) Rewrite() <-chan RedisCmd {
+	go func() {
+		defer close(o.cmdC)
+		switch o.typeByte {
+		case rdbTypeZSet:
+			o.readZset()
+		case rdbTypeZSet2:
+			o.readZset2()
+		case rdbTypeZSetZiplist:
+			o.readZsetZiplist()
+		case rdbTypeZSetListpack:
+			o.readZsetListpack()
+		default:
+			log.Panicf("unknown zset type. typeByte=[%d]", o.typeByte)
+		}
+	}()
+	return o.cmdC
+}
+
+func (o *ZsetObject) readZset() {
+	rd := o.rd
 	size := int(structure.ReadLength(rd))
-	o.elements = make([]ZSetEntry, size)
 	for i := 0; i < size; i++ {
-		o.elements[i].Member = structure.ReadString(rd)
+		member := structure.ReadString(rd)
 		score := structure.ReadFloat(rd)
-		o.elements[i].Score = fmt.Sprintf("%f", score)
+		o.cmdC <- RedisCmd{"zadd", o.key, fmt.Sprintf("%f", score), member}
 	}
 }
 
-func (o *ZsetObject) readZset2(rd io.Reader) {
+func (o *ZsetObject) readZset2() {
+	rd := o.rd
 	size := int(structure.ReadLength(rd))
-	o.elements = make([]ZSetEntry, size)
 	for i := 0; i < size; i++ {
-		o.elements[i].Member = structure.ReadString(rd)
+		member := structure.ReadString(rd)
 		score := structure.ReadDouble(rd)
-		o.elements[i].Score = fmt.Sprintf("%f", score)
+		o.cmdC <- RedisCmd{"zadd", o.key, fmt.Sprintf("%f", score), member}
 	}
 }
 
-func (o *ZsetObject) readZsetZiplist(rd io.Reader) {
+func (o *ZsetObject) readZsetZiplist() {
+	rd := o.rd
 	list := structure.ReadZipList(rd)
 	size := len(list)
 	if size%2 != 0 {
 		log.Panicf("zset listpack size is not even. size=[%d]", size)
 	}
-	o.elements = make([]ZSetEntry, size/2)
 	for i := 0; i < size; i += 2 {
-		o.elements[i/2].Member = list[i]
-		o.elements[i/2].Score = list[i+1]
+		member := list[i]
+		score := list[i+1]
+		o.cmdC <- RedisCmd{"zadd", o.key, score, member}
 	}
 }
 
-func (o *ZsetObject) readZsetListpack(rd io.Reader) {
+func (o *ZsetObject) readZsetListpack() {
+	rd := o.rd
 	list := structure.ReadListpack(rd)
 	size := len(list)
 	if size%2 != 0 {
 		log.Panicf("zset listpack size is not even. size=[%d]", size)
 	}
-	o.elements = make([]ZSetEntry, size/2)
 	for i := 0; i < size; i += 2 {
-		o.elements[i/2].Member = list[i]
-		o.elements[i/2].Score = list[i+1]
+		member := list[i]
+		score := list[i+1]
+		o.cmdC <- RedisCmd{"zadd", o.key, score, member}
 	}
-}
-
-func (o *ZsetObject) Rewrite() []RedisCmd {
-	cmds := make([]RedisCmd, len(o.elements))
-	for inx, ele := range o.elements {
-		cmd := RedisCmd{"zadd", o.key, ele.Score, ele.Member}
-		cmds[inx] = cmd
-	}
-	return cmds
 }

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -188,8 +188,8 @@ func (r *scanStandaloneReader) fetch() {
 			typeByte := dump[0]
 			anotherReader := strings.NewReader(dump[1 : len(dump)-10])
 			o := types.ParseObject(anotherReader, typeByte, key)
-			cmds := o.Rewrite()
-			for _, cmd := range cmds {
+			cmdC := o.Rewrite()
+			for cmd := range cmdC {
 				e := entry.NewEntry()
 				e.DbId = dbId
 				e.Argv = cmd


### PR DESCRIPTION
相关讨论：https://github.com/tair-opensource/RedisShake/issues/761

- 使用 channel 传递 RedisCmd。
- 修复了一个BUG： 不使用 restore 命令迁移 Stream 类型的时候，创建 consumer Group 应该使用 `XGROUP CREATE`，原来使用的是 `CREATE` 导致报错。