### PR TITLE
添加动态识别库号

### DIFF
--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -86,7 +86,8 @@ func main() {
 	}
 	// create writer
 	var theWriter writer.Writer
-	if v.IsSet("redis_writer") {
+	switch {
+	case v.IsSet("redis_writer"):
 		opts := new(writer.RedisWriterOptions)
 		defaults.SetDefaults(opts)
 		err := v.UnmarshalKey("redis_writer", opts)
@@ -109,10 +110,9 @@ func main() {
 			entry.Argv = []string{"FLUSHALL"}
 			theWriter.Write(entry)
 		}
-	} else {
+	default:
 		log.Panicf("no writer config entry found")
 	}
-
 	// create status
 	status.Init(theReader, theWriter)
 

--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -34,7 +34,8 @@ func main() {
 
 	// create reader
 	var theReader reader.Reader
-	if v.IsSet("sync_reader") {
+	switch {
+	case v.IsSet("sync_reader"):
 		opts := new(reader.SyncReaderOptions)
 		defaults.SetDefaults(opts)
 		err := v.UnmarshalKey("sync_reader", opts)
@@ -48,7 +49,7 @@ func main() {
 			theReader = reader.NewSyncStandaloneReader(ctx, opts)
 			log.Infof("create SyncStandaloneReader: %v", opts.Address)
 		}
-	} else if v.IsSet("scan_reader") {
+	case v.IsSet("scan_reader"):
 		opts := new(reader.ScanReaderOptions)
 		defaults.SetDefaults(opts)
 		err := v.UnmarshalKey("scan_reader", opts)
@@ -62,7 +63,7 @@ func main() {
 			theReader = reader.NewScanStandaloneReader(ctx, opts)
 			log.Infof("create ScanStandaloneReader: %v", opts.Address)
 		}
-	} else if v.IsSet("rdb_reader") {
+	case v.IsSet("rdb_reader"):
 		opts := new(reader.RdbReaderOptions)
 		defaults.SetDefaults(opts)
 		err := v.UnmarshalKey("rdb_reader", opts)
@@ -71,7 +72,7 @@ func main() {
 		}
 		theReader = reader.NewRDBReader(opts)
 		log.Infof("create RdbReader: %v", opts.Filepath)
-	} else if v.IsSet("aof_reader") {
+	case v.IsSet("aof_reader"):
 		opts := new(reader.AOFReaderOptions)
 		defaults.SetDefaults(opts)
 		err := v.UnmarshalKey("aof_reader", opts)
@@ -80,10 +81,9 @@ func main() {
 		}
 		theReader = reader.NewAOFReader(opts)
 		log.Infof("create AOFReader: %v", opts.Filepath)
-	} else {
+	default:
 		log.Panicf("no reader config entry found")
 	}
-
 	// create writer
 	var theWriter writer.Writer
 	if v.IsSet("redis_writer") {

--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -148,8 +148,8 @@ func (r *Redis) Close() {
 
 /* Commands */
 
-func (r *Redis) Scan(cursor uint64) (newCursor uint64, keys []string) {
-	r.Send("scan", strconv.FormatUint(cursor, 10), "count", "2048")
+func (r *Redis) Scan(cursor uint64, batch string) (newCursor uint64, keys []string) {
+	r.Send("scan", strconv.FormatUint(cursor, 10), "count", batch)
 	reply, err := r.Receive()
 	if err != nil {
 		log.Panicf(err.Error())

--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -71,7 +71,7 @@ func NewRedisClient(ctx context.Context, address string, username string, passwo
 	return r
 }
 
-func (r *Redis) DoWithStringReply(args ...string) string {
+func (r *Redis) DoWithStringReply(args ...interface{}) string {
 	r.Send(args...)
 
 	replyInterface, err := r.Receive()
@@ -82,7 +82,7 @@ func (r *Redis) DoWithStringReply(args ...string) string {
 	return reply
 }
 
-func (r *Redis) Do(args ...string) interface{} {
+func (r *Redis) Do(args ...interface{}) interface{} {
 	r.Send(args...)
 
 	reply, err := r.Receive()
@@ -92,7 +92,7 @@ func (r *Redis) Do(args ...string) interface{} {
 	return reply
 }
 
-func (r *Redis) Send(args ...string) {
+func (r *Redis) Send(args ...interface{}) {
 	argsInterface := make([]interface{}, len(args))
 	for inx, item := range args {
 		argsInterface[inx] = item
@@ -148,7 +148,7 @@ func (r *Redis) Close() {
 
 /* Commands */
 
-func (r *Redis) Scan(cursor uint64, count string) (newCursor uint64, keys []string) {
+func (r *Redis) Scan(cursor uint64, count int) (newCursor uint64, keys []string) {
 	r.Send("scan", strconv.FormatUint(cursor, 10), "count", count)
 	reply, err := r.Receive()
 	if err != nil {

--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -148,8 +148,8 @@ func (r *Redis) Close() {
 
 /* Commands */
 
-func (r *Redis) Scan(cursor uint64, batch string) (newCursor uint64, keys []string) {
-	r.Send("scan", strconv.FormatUint(cursor, 10), "count", batch)
+func (r *Redis) Scan(cursor uint64, count string) (newCursor uint64, keys []string) {
+	r.Send("scan", strconv.FormatUint(cursor, 10), "count", count)
 	reply, err := r.Receive()
 	if err != nil {
 		log.Panicf(err.Error())

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -26,7 +26,7 @@ type ScanReaderOptions struct {
 	KSN           bool   `mapstructure:"ksn" default:"false"`
 	DBS           []int  `mapstructure:"dbs"`
 	PreferReplica bool   `mapstructure:"prefer_replica" default:"false"`
-	Batch         int    `mapstructure:"batch" default:"2048"`
+	Count         int    `mapstructure:"count" default:"2048"`
 }
 
 type dbKey struct {
@@ -132,10 +132,10 @@ func (r *scanStandaloneReader) scan() {
 		}
 
 		var cursor uint64 = 0
-		batch := strconv.Itoa(r.opts.Batch)
+		count := strconv.Itoa(r.opts.Count)
 		for {
 			var keys []string
-			cursor, keys = c.Scan(cursor, batch)
+			cursor, keys = c.Scan(cursor, count)
 			for _, key := range keys {
 				r.keyQueue.Put(dbKey{dbId, key}) // pass value not pointer
 			}

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -132,7 +132,7 @@ func (r *scanStandaloneReader) scan() {
 		}
 
 		var cursor uint64 = 0
-		count := strconv.Itoa(r.opts.Count)
+		count := r.opts.Count
 		for {
 			var keys []string
 			cursor, keys = c.Scan(cursor, count)

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -58,7 +58,12 @@ func NewScanStandaloneReader(ctx context.Context, opts *ScanReaderOptions) Reade
 		r.dbs = []int{0}
 	} else {
 		if len(opts.DBS) == 0 {
-			r.dbs = []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+			c.Send("info", "keyspace")
+			info, err := c.Receive()
+			if err != nil {
+				log.Panicf(err.Error())
+			}
+			r.dbs = utils.ParseDBs(info.(string))
 		} else {
 			r.dbs = opts.DBS
 		}

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -106,8 +106,9 @@ func (r *scanStandaloneReader) subscript() {
 				if err != nil {
 					log.Panicf(err.Error())
 				}
-				key := resp.([]interface{})[3].(string)
-				dbId := regex.FindString(resp.([]interface{})[2].(string))
+				respSlice := resp.([]interface{})
+				key := respSlice[3].(string)
+				dbId := regex.FindString(respSlice[2].(string))
 				dbIdInt, err := strconv.Atoi(dbId)
 				if err != nil {
 					log.Panicf(err.Error())

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -26,6 +26,7 @@ type ScanReaderOptions struct {
 	KSN           bool   `mapstructure:"ksn" default:"false"`
 	DBS           []int  `mapstructure:"dbs"`
 	PreferReplica bool   `mapstructure:"prefer_replica" default:"false"`
+	Batch         int    `mapstructure:"batch" default:"2048"`
 }
 
 type dbKey struct {
@@ -131,9 +132,10 @@ func (r *scanStandaloneReader) scan() {
 		}
 
 		var cursor uint64 = 0
+		batch := strconv.Itoa(r.opts.Batch)
 		for {
 			var keys []string
-			cursor, keys = c.Scan(cursor)
+			cursor, keys = c.Scan(cursor, batch)
 			for _, key := range keys {
 				r.keyQueue.Put(dbKey{dbId, key}) // pass value not pointer
 			}

--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -116,7 +116,7 @@ func (r *syncStandaloneReader) StartRead(ctx context.Context) chan *entry.Entry 
 
 func (r *syncStandaloneReader) sendReplconfListenPort() {
 	// use status_port as redis-shake port
-	argv := []string{"replconf", "listening-port", strconv.Itoa(config.Opt.Advanced.StatusPort)}
+	argv := []interface{}{"replconf", "listening-port", strconv.Itoa(config.Opt.Advanced.StatusPort)}
 	r.client.Send(argv...)
 	_, err := r.client.Receive()
 	if err != nil {
@@ -126,9 +126,9 @@ func (r *syncStandaloneReader) sendReplconfListenPort() {
 
 func (r *syncStandaloneReader) sendPSync() {
 	// send PSync
-	argv := []string{"PSYNC", "?", "-1"}
+	argv := []interface{}{"PSYNC", "?", "-1"}
 	if config.Opt.Advanced.AwsPSync != "" {
-		argv = []string{config.Opt.Advanced.GetPSyncCommand(r.stat.Address), "?", "-1"}
+		argv = []interface{}{config.Opt.Advanced.GetPSyncCommand(r.stat.Address), "?", "-1"}
 	}
 	r.client.Send(argv...)
 

--- a/internal/utils/parse.go
+++ b/internal/utils/parse.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"regexp"
+	"strconv"
+)
+
+func ParseDBs(s string) []int {
+	dbsString := regexp.MustCompile(`db(\d+):`).FindAllStringSubmatch(s, -1)
+	if dbsString == nil {
+		return []int{}
+	}
+	dbs := make([]int, len(dbsString))
+	for i, dbString := range dbsString {
+		db, _ := strconv.Atoi(dbString[1])
+		dbs[i] = db
+	}
+	return dbs
+}


### PR DESCRIPTION
添加动态识别库号，兼容云上库号没有16个库带限制
添加scan时候的count控制配置，用来防止源端压力过高