### PR TITLE
Fix dead condition in LoadAppendOnlyFile

### DIFF
--- a/internal/reader/parsing_aof.go
+++ b/internal/reader/parsing_aof.go
@@ -601,15 +601,14 @@ func (aofInfo *INFO) LoadAppendOnlyFile(ctx context.Context, am *AOFManifest, AO
 			if ret == AOFEmpty {
 				ret = AOFOk
 			}
+			if ret == AOFOk || ret == AOFTruncated {
+				log.Infof("The AOF File was successfully loaded")
+			}
 			if ret == AOFOpenErr || ret == AOFFailed {
-				if ret == AOFOk || ret == AOFTruncated {
-					log.Infof("The AOF File was successfully loaded")
+				if ret == AOFOpenErr {
+					log.Panicf("There was an error opening the AOF File.")
 				} else {
-					if ret == AOFOpenErr {
-						log.Panicf("There was an error opening the AOF File.")
-					} else {
-						log.Panicf("Failed to open AOF File.")
-					}
+					log.Panicf("Failed to open AOF File.")
 				}
 				return ret
 			}


### PR DESCRIPTION
Currently, RedisShake checks the AOFOk and AOFTruncated return status inside the error if the condition that would never happen, it should be moved outside.

```Go
if ret == AOFOpenErr || ret == AOFFailed {
    if ret == AOFOk || ret == AOFTruncated {
...
```