### PR TITLE
No need to print WARNING message while receiving the null reply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # system
 .idea/
 __pycache__/
-.DS_Store/
+.DS_Store
 
 # compiled output or test output
 bin/


### PR DESCRIPTION
Currently, the writer will print the warning log if received the null reply. And it might confuse users since some write commands like the SET with the NX option will return a null reply if the key has already existed.