### PR TITLE
feat: Add support for sentinel writer

### DIFF
--- a/cmd/redis-shake/main.go
+++ b/cmd/redis-shake/main.go
@@ -100,6 +100,9 @@ func main() {
 		if opts.Cluster {
 			theWriter = writer.NewRedisClusterWriter(ctx, opts)
 			log.Infof("create RedisClusterWriter: %v", opts.Address)
+		} else if opts.Sentinel {
+			theWriter = writer.NewRedisSentinelWriter(ctx, opts)
+			log.Infof("create RedisSentinelWriter: %v", opts.Address)
 		} else {
 			theWriter = writer.NewRedisStandaloneWriter(ctx, opts)
 			log.Infof("create RedisStandaloneWriter: %v", opts.Address)

--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -20,6 +20,10 @@ type Redis struct {
 	protoWriter *proto.Writer
 }
 
+func NewSentinelClient(ctx context.Context, address string, Tls bool) *Redis {
+	return NewRedisClient(ctx, address, "", "", Tls)
+}
+
 func NewRedisClient(ctx context.Context, address string, username string, password string, Tls bool) *Redis {
 	r := new(Redis)
 	var conn net.Conn

--- a/internal/writer/redis_sentinel_writer.go
+++ b/internal/writer/redis_sentinel_writer.go
@@ -1,0 +1,30 @@
+package writer
+
+import (
+	"RedisShake/internal/client"
+	"RedisShake/internal/log"
+	"context"
+	"fmt"
+)
+
+func NewRedisSentinelWriter(ctx context.Context, opts *RedisWriterOptions) Writer {
+	sentinel := client.NewSentinelClient(ctx, opts.Address, opts.Tls)
+	sentinel.Send("SENTINEL", "GET-MASTER-ADDR-BY-NAME", opts.Master)
+	addr, err := sentinel.Receive()
+	if err != nil {
+		log.Panicf(err.Error())
+	}
+	hostport := addr.([]interface{})
+	address := fmt.Sprintf("%s:%s", hostport[0].(string), hostport[1].(string))
+	sentinel.Close()
+
+	redisOpt := &RedisWriterOptions{
+		Address:  address,
+		Username: opts.Username,
+		Password: opts.Password,
+		Tls:      opts.Tls,
+		OffReply: opts.OffReply,
+	}
+	log.Infof("connecting to master node at %s", redisOpt.Address)
+	return NewRedisStandaloneWriter(ctx, redisOpt)
+}

--- a/shake.toml
+++ b/shake.toml
@@ -31,6 +31,8 @@ prefer_replica = true # set to true if you want to sync from replica node
 
 [redis_writer]
 cluster = false            # set to true if target is a redis cluster
+sentinel = false           # set to true if target is a redis sentinel
+master = ""                # set to master name if target is a redis sentinel
 address = "127.0.0.1:6380" # when cluster is true, set address to one of the cluster node
 username = ""              # keep empty if not using ACL
 password = ""              # keep empty if no authentication is required


### PR DESCRIPTION
We have a case where the target is using sentinel.

And manually configuring the master address in redis-shake is cumbersome because the Redis master changes anytime due to failover to a new master node. 
