### PR TITLE
Update the comment of rdb_restore_command_behavior in shake.toml

### DIFF
--- a/shake.toml
+++ b/shake.toml
@@ -57,7 +57,7 @@ log_interval = 5       # in seconds
 # to change the default behavior of restore:
 # panic:   redis-shake will stop when meet "Target key name is busy" error.
 # rewrite: redis-shake will replace the key with new value.
-# ignore:  redis-shake will skip restore the key when meet "Target key name is busy" error.
+# skip:  redis-shake will skip restore the key when meet "Target key name is busy" error.
 rdb_restore_command_behavior = "panic" # panic, rewrite or skip
 
 # redis-shake uses pipeline to improve sending performance.


### PR DESCRIPTION
There are two inconsistencies in the description of the "rdb_restore_command_behavior" configuration in the [advanced] section when  the developer sees the comment.