### PR TITLE
fix double precision ，module bloomfilter double to string

### DIFF
--- a/internal/rdb/structure/module2_struct.go
+++ b/internal/rdb/structure/module2_struct.go
@@ -50,7 +50,7 @@ func ReadModuleDouble(rd io.Reader) string {
 		log.Panicf("Unknown module double encode type")
 	}
 	value := ReadDouble(rd)
-	return fmt.Sprintf("%g", value)
+	return fmt.Sprintf("%.15f", value)
 }
 
 func ReadModuleString(rd io.Reader) string {

--- a/internal/rdb/structure/module2_struct.go
+++ b/internal/rdb/structure/module2_struct.go
@@ -50,7 +50,7 @@ func ReadModuleDouble(rd io.Reader) string {
 		log.Panicf("Unknown module double encode type")
 	}
 	value := ReadDouble(rd)
-	return fmt.Sprintf("%f", value)
+	return fmt.Sprintf("%g", value)
 }
 
 func ReadModuleString(rd io.Reader) string {


### PR DESCRIPTION
fix double precision ，module double to string
当我们使用redisshake迁移的时候 发现 bloomfilter 模块 无法迁移 精度超过 0.000001的 ratio字段，因为最后他会白这个精度 ratio修改成0，这会导致 记载 boomfilter过滤器的实例无法 bgsave，因为 ratio默认不会为0， 最后经过排查发现是 redisshake精度转换有问题。
tips：  ratio每次库容 都会 降低一个数量级。
迁移后 目标端会成为这种情况。
```
127.0.0.1:6379> bf.debug myboom
1) "size:1372567"
2) "bytes:4194304 bits:33554432 hashes:24 hashwidth:64 capacity:1000200 size:1000200 ratio:0"
3) "bytes:16777216 bits:134217728 hashes:26 hashwidth:64 capacity:3683950 size:372367 ratio:0"
```

当然我也查看了一下 调用此函数的其他地方，tairzset 的rewrite 功能也会导致 精度丧失。我觉得这是一个比较严重的 bug。