### PR TITLE
Fix missing loading group offset for stream if its type is RDB_TYPE_STREAM_LISTPACKS_3

### DIFF
--- a/internal/rdb/types/stream.go
+++ b/internal/rdb/types/stream.go
@@ -188,7 +188,7 @@ func (o *StreamObject) readStream() {
 		cmdC <- []string{"XGROUP", "CREATE", masterKey, groupName, lastid}
 
 		/* Load group offset. */
-		if typeByte == rdbTypeStreamListpacks2 {
+		if typeByte >= rdbTypeStreamListpacks2 {
 			_ = structure.ReadLength(rd) // offset
 		}
 


### PR DESCRIPTION
redis code: https://github.com/redis/redis/blob/unstable/src/rdb.c#L2927