### PR TITLE
fix: resolve Shake client hang in HandShaking state due to source Redis blocking during AofRewrite

### DIFF
--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -189,7 +189,7 @@ func (r *syncStandaloneReader) checkBgsaveInProgress() {
 			argv := []interface{}{"INFO", "persistence"}
 			r.client.Send(argv...)
 			receiveString := r.client.ReceiveString()
-			if strings.Contains(receiveString, "rdb_bgsave_in_progress:1") {
+			if strings.Contains(receiveString, "rdb_bgsave_in_progress:1") || strings.Contains(receiveString, "aof_rewrite_in_progress:1") {
 				log.Warnf("[%s] source db is doing bgsave, waiting for a while.", r.stat.Name)
 			} else {
 				log.Infof("[%s] source db is not doing bgsave! continue.", r.stat.Name)


### PR DESCRIPTION
The issue was resolved where the source Redis database, during AofRewrite, would block the Shake client, causing the client to hang in the HandShaking state.

解决了源Redis数据库自身处在Aof重写时，会阻塞Shake客户端导致客户端假死在HandShaking状态，和bgsave时表现一致

![企业微信截图_17315521508887](https://github.com/user-attachments/assets/37e332e7-18a0-46c5-ac2b-771589ac0795)
