### PR TITLE
feat: redis-writer add buffered sending to significantly improve speed

### DIFF
--- a/shake.toml
+++ b/shake.toml
@@ -36,6 +36,7 @@ username = ""              # keep empty if not using ACL
 password = ""              # keep empty if no authentication is required
 tls = false
 off_reply = false          # turn off the server reply
+buff_send = false          # buffer send, default false. may be a sync delay when true, but it can greatly improve the speed
 
 [filter]
 # Allow keys with specific prefixes or suffixes
@@ -64,8 +65,8 @@ block_db = []
 #   allow_command = ["GET", "SET"]  # Only allow GET and SET commands
 #   block_command = ["DEL", "FLUSHDB"]  # Block DEL and FLUSHDB commands
 # Leave empty to allow all commands
-allow_command = [] 
-block_command = [] 
+allow_command = []
+block_command = []
 
 # Allow or block specific command groups
 # Available groups:
@@ -76,8 +77,8 @@ block_command = []
 #   allow_command_group = ["STRING", "HASH"]  # Only allow STRING and HASH commands
 #   block_command_group = ["SCRIPTING", "PUBSUB"]  # Block SCRIPTING and PUBSUB commands
 # Leave empty to allow all command groups
-allow_command_group = [] 
-block_command_group = [] 
+allow_command_group = []
+block_command_group = []
 
 # Function for custom data processing
 # For best practices and examples, visit:
@@ -112,7 +113,7 @@ rdb_restore_command_behavior = "panic" # panic, rewrite or skip
 pipeline_count_limit = 1024
 
 # This setting corresponds to the 'client-query-buffer-limit' in Redis configuration.
-# The default value is typically 1GB. 
+# The default value is typically 1GB.
 # It's recommended not to modify this value unless absolutely necessary.
 target_redis_client_max_querybuf_len = 1073741824  # 1GB in bytes
 
@@ -122,7 +123,7 @@ target_redis_client_max_querybuf_len = 1073741824  # 1GB in bytes
 # It's recommended not to modify this value unless absolutely necessary.
 target_redis_proto_max_bulk_len = 512_000_000
 
-# If the source is Elasticache, you can set this item. AWS ElastiCache has custom 
+# If the source is Elasticache, you can set this item. AWS ElastiCache has custom
 # psync command, which can be obtained through a ticket.
 aws_psync = "" # example: aws_psync = "10.0.0.1:6379@nmfu2sl5osync,10.0.0.1:6379@xhma21xfkssync"
 


### PR DESCRIPTION

新增了Redis-Writer 缓冲区延迟写入功能，可大增几倍不止的写入速度。原写入方式由于在buffio中频繁flush导致syscall过多，延迟暴增。issue：https://github.com/tair-opensource/RedisShake/issues/878

未加入延迟flush：
![image](https://github.com/user-attachments/assets/e4d8416d-d811-42dd-a09a-0a841b5756d1)

加入延迟flush后：
![image](https://github.com/user-attachments/assets/11a3030b-5f00-4fa1-bd78-30cd5f72f4e3)
