### PR TITLE
feat: support separate authentication for Sentinel and Redis

### DIFF
--- a/internal/writer/redis_sentinel_writer.go
+++ b/internal/writer/redis_sentinel_writer.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewRedisSentinelWriter(ctx context.Context, opts *RedisWriterOptions) Writer {
-	sentinel := client.NewSentinelMasterClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls)
+	sentinel := client.NewSentinelMasterClient(ctx, opts.Address, opts.SentinelUsername, opts.SentinelPassword, opts.Tls)
 	sentinel.Send("SENTINEL", "GET-MASTER-ADDR-BY-NAME", opts.Master)
 	addr, err := sentinel.Receive()
 	if err != nil {

--- a/internal/writer/redis_sentinel_writer.go
+++ b/internal/writer/redis_sentinel_writer.go
@@ -24,6 +24,7 @@ func NewRedisSentinelWriter(ctx context.Context, opts *RedisWriterOptions) Write
 		Password: opts.Password,
 		Tls:      opts.Tls,
 		OffReply: opts.OffReply,
+		BuffSend: opts.BuffSend,
 	}
 	log.Infof("connecting to master node at %s", redisOpt.Address)
 	return NewRedisStandaloneWriter(ctx, redisOpt)

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -28,7 +28,7 @@ type RedisWriterOptions struct {
 	SentinelPassword string `mapstructure:"sentinel_password" default:""`
 	Tls              bool   `mapstructure:"tls" default:"false"`
 	OffReply         bool   `mapstructure:"off_reply" default:"false"`
-  BuffSend         bool   `mapstructure:"buff_send" default:"false"`
+        BuffSend         bool   `mapstructure:"buff_send" default:"false"`
 }
 
 type redisStandaloneWriter struct {

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -18,14 +18,16 @@ import (
 )
 
 type RedisWriterOptions struct {
-	Cluster  bool   `mapstructure:"cluster" default:"false"`
-	Sentinel bool   `mapstructure:"sentinel" default:"false"`
-	Master   string `mapstructure:"master" default:""`
-	Address  string `mapstructure:"address" default:""`
-	Username string `mapstructure:"username" default:""`
-	Password string `mapstructure:"password" default:""`
-	Tls      bool   `mapstructure:"tls" default:"false"`
-	OffReply bool   `mapstructure:"off_reply" default:"false"`
+	Cluster          bool   `mapstructure:"cluster" default:"false"`
+	Sentinel         bool   `mapstructure:"sentinel" default:"false"`
+	Master           string `mapstructure:"master" default:""`
+	Address          string `mapstructure:"address" default:""`
+	Username         string `mapstructure:"username" default:""`
+	Password         string `mapstructure:"password" default:""`
+	SentinelUsername string `mapstructure:"sentinel_username" default:""`
+	SentinelPassword string `mapstructure:"sentinel_password" default:""`
+	Tls              bool   `mapstructure:"tls" default:"false"`
+	OffReply         bool   `mapstructure:"off_reply" default:"false"`
 }
 
 type redisStandaloneWriter struct {

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -28,7 +28,7 @@ type RedisWriterOptions struct {
 	SentinelPassword string `mapstructure:"sentinel_password" default:""`
 	Tls              bool   `mapstructure:"tls" default:"false"`
 	OffReply         bool   `mapstructure:"off_reply" default:"false"`
-        BuffSend         bool   `mapstructure:"buff_send" default:"false"`
+	BuffSend         bool   `mapstructure:"buff_send" default:"false"`
 }
 
 type redisStandaloneWriter struct {

--- a/shake.toml
+++ b/shake.toml
@@ -34,6 +34,8 @@ master = ""                # set to master name if target is a redis sentinel
 address = "127.0.0.1:6380" # when cluster is true, set address to one of the cluster node
 username = ""              # keep empty if not using ACL
 password = ""              # keep empty if no authentication is required
+sentinel_username = ""     # keep empty if not using sentinel ACL
+sentinel_password = ""     # keep empty if sentinel no authentication is required
 tls = false
 off_reply = false          # turn off the server reply
 
@@ -70,8 +72,8 @@ block_db = []
 #   allow_command = ["GET", "SET"]  # Only allow GET and SET commands
 #   block_command = ["DEL", "FLUSHDB"]  # Block DEL and FLUSHDB commands
 # Leave empty to allow all commands
-allow_command = [] 
-block_command = [] 
+allow_command = []
+block_command = []
 
 # Allow or block specific command groups
 # Available groups:
@@ -82,8 +84,8 @@ block_command = []
 #   allow_command_group = ["STRING", "HASH"]  # Only allow STRING and HASH commands
 #   block_command_group = ["SCRIPTING", "PUBSUB"]  # Block SCRIPTING and PUBSUB commands
 # Leave empty to allow all command groups
-allow_command_group = [] 
-block_command_group = [] 
+allow_command_group = []
+block_command_group = []
 
 # Function for custom data processing
 # For best practices and examples, visit:
@@ -118,7 +120,7 @@ rdb_restore_command_behavior = "panic" # panic, rewrite or skip
 pipeline_count_limit = 1024
 
 # This setting corresponds to the 'client-query-buffer-limit' in Redis configuration.
-# The default value is typically 1GB. 
+# The default value is typically 1GB.
 # It's recommended not to modify this value unless absolutely necessary.
 target_redis_client_max_querybuf_len = 1073741824  # 1GB in bytes
 
@@ -128,7 +130,7 @@ target_redis_client_max_querybuf_len = 1073741824  # 1GB in bytes
 # It's recommended not to modify this value unless absolutely necessary.
 target_redis_proto_max_bulk_len = 512_000_000
 
-# If the source is Elasticache, you can set this item. AWS ElastiCache has custom 
+# If the source is Elasticache, you can set this item. AWS ElastiCache has custom
 # psync command, which can be obtained through a ticket.
 aws_psync = "" # example: aws_psync = "10.0.0.1:6379@nmfu2sl5osync,10.0.0.1:6379@xhma21xfkssync"
 


### PR DESCRIPTION
feat: support separate authentication for Sentinel and Redis
- Add support for distinct username and password for Sentinel and Redis.
- Resolve issues with connecting when Sentinel has no authentication but Redis does.
- Handle scenarios where Sentinel and Redis have different authentication configurations.
- Improve client logic to dynamically manage authentication based on configuration.

BREAKING CHANGE: Requires configuration update to specify separate Sentinel and Redis credentials.

功能：支持 Sentinel 和 Redis 的单独身份验证

- 为 Sentinel 和 Redis 添加对不同用户名和密码的支持。
- 解决当 Sentinel 没有身份验证而 Redis 有身份验证时的连接问题。
- 处理 Sentinel 和 Redis 具有不同身份验证配置的情况。
- 改进客户端逻辑，以便根据配置动态管理身份验证。

重大变更：需要更新配置以指定独立的 Sentinel 和 Redis 的身份验证。
