### PR TITLE
fix: resolve timeout and performance issues in buffer write mode and AOF writes

### DIFF
--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -204,9 +204,6 @@ func (r *Redis) SendBytesBuff(buf []byte) {
 }
 
 func (r *Redis) flushBuff() {
-	if atomic.AddUint64(&r.sendCount, 1)%100 != 0 {
-		return
-	}
 	if !r.timer.Stop() {
 		select {
 		case <-r.timer.C:
@@ -214,6 +211,9 @@ func (r *Redis) flushBuff() {
 		}
 	}
 	r.timer.Reset(time.Second)
+	if atomic.AddUint64(&r.sendCount, 1)%100 != 0 {
+		return
+	}
 	r.flush()
 }
 

--- a/internal/utils/file_rotate/aof_writer.go
+++ b/internal/utils/file_rotate/aof_writer.go
@@ -50,10 +50,6 @@ func (w *AOFWriter) Write(buf []byte) {
 		w.Close()
 		w.openFile(w.offset)
 	}
-	err = w.file.Sync()
-	if err != nil {
-		log.Panicf(err.Error())
-	}
 }
 
 func (w *AOFWriter) Close() {


### PR DESCRIPTION
fix: resolve timeout and performance issues in buffer write mode and AOF writes
- resolve timeout issue after small-batch writes in buffer mode
- address high disk usage and write bottleneck caused by forced AOF file sync

- 解决redis_writer缓冲区模式下小批量写入后的超时不提交问题
- 解决强制AOF文件同步导致的磁盘占用高和写入瓶颈问题
