### PR TITLE
Feat: Too small buffer size for data transmission and rdb read-write

### DIFF
--- a/internal/aof/aof.go
+++ b/internal/aof/aof.go
@@ -25,12 +25,15 @@ const (
 type Loader struct {
 	filePath string
 	ch       chan *entry.Entry
+	bufSize  int
 }
 
-func NewLoader(filePath string, ch chan *entry.Entry) *Loader {
+func NewLoader(filePath string, bufSize int, ch chan *entry.Entry) *Loader {
 	ld := new(Loader)
 	ld.ch = ch
 	ld.filePath = filePath
+	ld.bufSize = bufSize
+
 	return ld
 }
 
@@ -72,14 +75,13 @@ func (ld *Loader) LoadSingleAppendOnlyFile(ctx context.Context, timestamp int64)
 				log.Infof("The append log File %v doesn't exist: %v", filePath, err.Error())
 				return NotExist
 			}
-
 		}
 		stat, _ := fp.Stat()
 		if stat.Size() == 0 {
 			return Empty
 		}
 	}
-	reader := bufio.NewReader(fp)
+	reader := bufio.NewReaderSize(fp, ld.bufSize)
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/aof/aof_test.go
+++ b/internal/aof/aof_test.go
@@ -1,0 +1,44 @@
+package aof
+
+import (
+	"reflect"
+	"testing"
+
+	"RedisShake/internal/entry"
+)
+
+var mockEntryChan = make(chan *entry.Entry, 1)
+
+func TestNewLoader(t *testing.T) {
+	type args struct {
+		filePath string
+		bufSize  int
+		ch       chan *entry.Entry
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Loader
+	}{
+		{
+			name: "TestNewLoader",
+			args: args{
+				filePath: "test",
+				bufSize:  1,
+				ch:       mockEntryChan,
+			},
+			want: &Loader{
+				filePath: "test",
+				ch:       mockEntryChan,
+				bufSize:  1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewLoader(tt.args.filePath, tt.args.bufSize, tt.args.ch); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewLoader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -2,6 +2,7 @@ package rdb
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"RedisShake/internal/entry"
@@ -14,17 +15,58 @@ func BenchmarkParseRDB(b *testing.B) {
 	b.ResetTimer()
 	tempChan := make(chan *entry.Entry, 1024)
 	updateFunc := func(offset int64) {
-
 	}
 	b.N = 20
 
 	for i := 0; i < b.N; i++ {
-		loader := NewLoader("rdb", updateFunc, "./dump.rdb", tempChan)
+		loader := NewLoader("rdb", 4096, updateFunc, "./dump.rdb", tempChan)
 		go func() {
 			for temp := range tempChan {
 				print(temp.CmdName)
 			}
 		}()
 		loader.ParseRDB(context.Background())
+	}
+}
+
+var mockEntryChan = make(chan *entry.Entry, 1)
+
+func TestNewLoader(t *testing.T) {
+	type args struct {
+		name       string
+		bufSize    int
+		updateFunc func(int64)
+		filPath    string
+		ch         chan *entry.Entry
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Loader
+	}{
+		{
+			name: "TestNewLoader",
+			args: args{
+				name:       "test",
+				bufSize:    1,
+				updateFunc: nil,
+				filPath:    "fillpath",
+				ch:         mockEntryChan,
+			},
+			want: &Loader{
+				name:       "test",
+				bufSize:    1,
+				updateFunc: nil,
+				filPath:    "fillpath",
+				ch:         mockEntryChan,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewLoader(tt.args.name, tt.args.bufSize, tt.args.updateFunc, tt.args.filPath, tt.args.ch); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewLoader() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/reader/aof_reader_test.go
+++ b/internal/reader/aof_reader_test.go
@@ -1,0 +1,43 @@
+package reader
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewAOFReader(t *testing.T) {
+	type args struct {
+		opts *AOFReaderOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want *aofReader
+	}{
+		{
+			name: "TestNewAOFReader",
+			args: args{
+				opts: &AOFReaderOptions{
+					Filepath:      "/tmp",
+					AOFTimestamp:  1,
+					ReaderBufSize: 1,
+				},
+			},
+			want: &aofReader{
+				bufSize: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInterface := NewAOFReader(tt.args.opts)
+			got, err := (gotInterface).(*aofReader)
+			if !err {
+				t.Errorf("NewAOFReader() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got.bufSize, tt.want.bufSize) {
+				t.Errorf("NewAOFReader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reader/parsing_aof_test.go
+++ b/internal/reader/parsing_aof_test.go
@@ -1,0 +1,42 @@
+package reader
+
+import (
+	"reflect"
+	"testing"
+
+	"RedisShake/internal/entry"
+)
+
+func TestNewAOFFileInfo(t *testing.T) {
+	type args struct {
+		aofFilePath string
+		bufSize     int
+		ch          chan *entry.Entry
+	}
+	tests := []struct {
+		name string
+		args args
+		want *INFO
+	}{
+		{
+			name: "TestNewAOFFileInfo",
+			args: args{
+				aofFilePath: "/tmp",
+				bufSize:     1,
+				ch:          nil,
+			},
+			want: &INFO{
+				ReaderBufSize: 1,
+				AOFDirName:    "/",
+				AOFFileName:   "tmp",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewAOFFileInfo(tt.args.aofFilePath, tt.args.bufSize, tt.args.ch); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewAOFFileInfo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reader/rdb_reader_test.go
+++ b/internal/reader/rdb_reader_test.go
@@ -1,0 +1,42 @@
+package reader
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewRDBReader(t *testing.T) {
+	type args struct {
+		opts *RdbReaderOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want *rdbReader
+	}{
+		{
+			name: "TestNewRDBReader",
+			args: args{
+				opts: &RdbReaderOptions{
+					Filepath:      "/tmp",
+					ReaderBufSize: 1,
+				},
+			},
+			want: &rdbReader{
+				bufSize: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInterface := NewRDBReader(tt.args.opts)
+			got, err := (gotInterface).(*rdbReader)
+			if !err {
+				t.Errorf("NewRDBReader() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got.bufSize, tt.want.bufSize) {
+				t.Errorf("NewRDBReader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reader/scan_standalone_reader_test.go
+++ b/internal/reader/scan_standalone_reader_test.go
@@ -1,0 +1,64 @@
+package reader
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/spf13/viper"
+)
+
+func TestScanReaderOptions(t *testing.T) {
+	type args struct {
+		config string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *ScanReaderOptions
+	}{
+		{
+			name: "TestReaderOptions",
+			args: args{
+				config: ``,
+			},
+			want: &ScanReaderOptions{
+				TCPReaderBufSize: 4096,
+				TCPWriterBufSize: 4096,
+			},
+		},
+		{
+			name: "TestReaderOptions",
+			args: args{
+				config: `
+tcp_reader_buf_size = 4095 # set to default value of bufio.NewReader
+tcp_writer_buf_size = 4097  # set to default value of bufio.NewWriter
+`,
+			},
+			want: &ScanReaderOptions{
+				TCPReaderBufSize: 4095,
+				TCPWriterBufSize: 4097,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("toml")
+			v.ReadConfig(bytes.NewBufferString(tt.args.config))
+			got := new(SyncReaderOptions)
+			defaults.SetDefaults(got)
+			if err := v.Unmarshal(got); err != nil {
+				t.Errorf("ScanReaderOptions() error = %v", err)
+				return
+			}
+
+			if got.TCPReaderBufSize != tt.want.TCPReaderBufSize ||
+				got.TCPWriterBufSize != tt.want.TCPWriterBufSize {
+				t.Errorf("ScanReaderOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reader/sync_standalone_reader_test.go
+++ b/internal/reader/sync_standalone_reader_test.go
@@ -1,0 +1,72 @@
+package reader
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/spf13/viper"
+)
+
+func TestSyncReaderOptions(t *testing.T) {
+	type args struct {
+		config string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *SyncReaderOptions
+	}{
+		{
+			name: "TestReaderOptions",
+			args: args{
+				config: ``,
+			},
+			want: &SyncReaderOptions{
+				TCPReaderBufSize: 4096,
+				TCPWriterBufSize: 4096,
+				RDBReaderBufSize: 4096,
+				RDBWriterBufSize: 33554432,
+			},
+		},
+		{
+			name: "TestReaderOptions",
+			args: args{
+				config: `
+tcp_reader_buf_size = 4095 # set to default value of bufio.NewReader
+tcp_writer_buf_size = 4097  # set to default value of bufio.NewWriter
+rdb_reader_buf_size = 4098 # set to default value of bufio.NewReader
+rdb_writer_buf_size = 33554433 # 32*1024*1024+1
+`,
+			},
+			want: &SyncReaderOptions{
+				TCPReaderBufSize: 4095,
+				TCPWriterBufSize: 4097,
+				RDBReaderBufSize: 4098,
+				RDBWriterBufSize: 33554433,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("toml")
+			v.ReadConfig(bytes.NewBufferString(tt.args.config))
+			got := new(SyncReaderOptions)
+			defaults.SetDefaults(got)
+			if err := v.Unmarshal(got); err != nil {
+				t.Errorf("ScanReaderOptions() error = %v", err)
+				return
+			}
+
+			if got.TCPReaderBufSize != tt.want.TCPReaderBufSize ||
+				got.TCPWriterBufSize != tt.want.TCPWriterBufSize ||
+				got.RDBReaderBufSize != tt.want.RDBReaderBufSize ||
+				got.RDBWriterBufSize != tt.want.RDBWriterBufSize {
+				t.Errorf("ScanReaderOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shake.toml
+++ b/shake.toml
@@ -8,6 +8,10 @@ sync_rdb = true            # set to false if you don't want to sync rdb
 sync_aof = true            # set to false if you don't want to sync aof
 prefer_replica = false     # set to true if you want to sync from replica node
 try_diskless = false       # set to true if you want to sync by socket and source repl-diskless-sync=yes
+tcp_reader_buf_size = 4096 # set to default value of bufio.NewReader
+tcp_writer_buf_size = 4096  # set to default value of bufio.NewWriter
+rdb_reader_buf_size = 4096 # set to default value of bufio.NewReader
+rdb_writer_buf_size = 33554432 # 32*1024*1024
 
 #[scan_reader]
 #cluster = false            # set to true if source is a redis cluster
@@ -19,13 +23,17 @@ try_diskless = false       # set to true if you want to sync by socket and sourc
 #scan = true                # set to false if you don't want to scan keys
 #ksn = false                # set to true to enabled Redis keyspace notifications (KSN) subscription
 #count = 1                  # number of keys to scan per iteration
+#tcp_reader_buf_size = 4096 # set to default value of bufio.NewReader
+#tcp_writer_buf_size = 4096  # set to default value of bufio.NewWriter
 
 # [rdb_reader]
 # filepath = "/tmp/dump.rdb"
+# reader_buf_size = 4096 # set to default value of bufio.NewReader
 
 # [aof_reader]
 # filepath = "/tmp/.aof"
 # timestamp = 0            # subsecond
+# reader_buf_size = 4096 # set to default value of bufio.NewReader
 
 [redis_writer]
 cluster = false            # set to true if target is a redis cluster


### PR DESCRIPTION
### Bugs
1. `func (r *syncStandaloneReader) receiveRDB() string` pass a writer  instead of a BufferWriter when call `receiveRDBWithoutDiskless`
2. `func (r *syncStandaloneReader) receiveRDBWithoutDiskless(marker string, wt io.Writer)` use 32MB `buf` to buffer tcp data before every write to file, and hoping to call `Write` function once every 32M cycles. 
3. But the default buffer size of `bufio.Reader` is 4096, so each call of `r.rd.Read(buf[:readOnce])` can only return up to 4k data, and then will call `Write` function and write to File

### Fix
1. use BufferWriter when calling `func (r *syncStandaloneReader) receiveRDBWithoutDiskless(marker string, wt io.Writer)` 
2. Add reader/writer buffer size options for both tcp for scenarios of data transmission and rdb read-write