### PR TITLE
feat: add mTLS configuration support for Redis client connections

### DIFF
--- a/internal/client/sentinel.go
+++ b/internal/client/sentinel.go
@@ -7,18 +7,19 @@ import (
 )
 
 type SentinelOptions struct {
-	MasterName string `mapstructure:"master_name" default:""`
-	Address    string `mapstructure:"address" default:""`
-	Username   string `mapstructure:"username" default:""`
-	Password   string `mapstructure:"password" default:""`
-	Tls        bool   `mapstructure:"tls" default:"false"`
+	MasterName string    `mapstructure:"master_name" default:""`
+	Address    string    `mapstructure:"address" default:""`
+	Username   string    `mapstructure:"username" default:""`
+	Password   string    `mapstructure:"password" default:""`
+	Tls        bool      `mapstructure:"tls" default:"false"`
+	TlsConfig  TlsConfig `mapstructure:"tls_config" default:"{}"`
 }
 
 func FetchAddressFromSentinel(opts *SentinelOptions) string {
 	log.Infof("fetching master address from sentinel. sentinel address: %s, master name: %s", opts.Address, opts.MasterName)
 
 	ctx := context.Background()
-	c := NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, false)
+	c := NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, false)
 	defer c.Close()
 	c.Send("SENTINEL", "GET-MASTER-ADDR-BY-NAME", opts.MasterName)
 	hostport := ArrayString(c.Receive())

--- a/internal/reader/scan_cluster_reader.go
+++ b/internal/reader/scan_cluster_reader.go
@@ -14,7 +14,7 @@ type scanClusterReader struct {
 }
 
 func NewScanClusterReader(ctx context.Context, opts *ScanReaderOptions) Reader {
-	addresses, _ := utils.GetRedisClusterNodes(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.PreferReplica)
+	addresses, _ := utils.GetRedisClusterNodes(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, opts.PreferReplica)
 
 	rd := &scanClusterReader{}
 	for _, address := range addresses {

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -19,16 +19,17 @@ import (
 )
 
 type ScanReaderOptions struct {
-	Cluster       bool   `mapstructure:"cluster" default:"false"`
-	Address       string `mapstructure:"address" default:""`
-	Username      string `mapstructure:"username" default:""`
-	Password      string `mapstructure:"password" default:""`
-	Tls           bool   `mapstructure:"tls" default:"false"`
-	Scan          bool   `mapstructure:"scan" default:"true"`
-	KSN           bool   `mapstructure:"ksn" default:"false"`
-	DBS           []int  `mapstructure:"dbs"`
-	PreferReplica bool   `mapstructure:"prefer_replica" default:"false"`
-	Count         int    `mapstructure:"count" default:"1"`
+	Cluster       bool             `mapstructure:"cluster" default:"false"`
+	Address       string           `mapstructure:"address" default:""`
+	Username      string           `mapstructure:"username" default:""`
+	Password      string           `mapstructure:"password" default:""`
+	Tls           bool             `mapstructure:"tls" default:"false"`
+	TlsConfig     client.TlsConfig `mapstructure:"tls_config" default:"{}"`
+	Scan          bool             `mapstructure:"scan" default:"true"`
+	KSN           bool             `mapstructure:"ksn" default:"false"`
+	DBS           []int            `mapstructure:"dbs"`
+	PreferReplica bool             `mapstructure:"prefer_replica" default:"false"`
+	Count         int              `mapstructure:"count" default:"1"`
 }
 
 type dbKey struct {
@@ -63,7 +64,7 @@ type scanStandaloneReader struct {
 func NewScanStandaloneReader(ctx context.Context, opts *ScanReaderOptions) Reader {
 	r := new(scanStandaloneReader)
 	// dbs
-	c := client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.PreferReplica)
+	c := client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, opts.PreferReplica)
 	if len(opts.DBS) != 0 {
 		r.dbs = opts.DBS
 	} else if c.IsCluster() { // not use opts.Cluster, because user may use standalone mode to scan a cluster node
@@ -99,7 +100,7 @@ func (r *scanStandaloneReader) StartRead(ctx context.Context) []chan *entry.Entr
 }
 
 func (r *scanStandaloneReader) subscript() {
-	c := client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.PreferReplica)
+	c := client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.TlsConfig, r.opts.PreferReplica)
 	if len(r.dbs) == 0 {
 		c.Send("psubscribe", "__keyevent@*__:*")
 	} else {
@@ -148,7 +149,7 @@ func (r *scanStandaloneReader) subscript() {
 }
 
 func (r *scanStandaloneReader) scan() {
-	c := client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.PreferReplica)
+	c := client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.TlsConfig, r.opts.PreferReplica)
 	defer c.Close()
 	for _, dbId := range r.dbs {
 		if dbId != 0 {
@@ -193,7 +194,7 @@ func (r *scanStandaloneReader) scan() {
 
 func (r *scanStandaloneReader) dump() {
 	nowDbId := 0
-	r.dumpClient = client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.PreferReplica)
+	r.dumpClient = client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.TlsConfig, r.opts.PreferReplica)
 	// Support prefer_replica=true in both Cluster and Standalone mode
 	if r.opts.PreferReplica {
 		r.dumpClient.Do("READONLY")

--- a/internal/reader/sync_cluster_reader.go
+++ b/internal/reader/sync_cluster_reader.go
@@ -15,7 +15,7 @@ type syncClusterReader struct {
 }
 
 func NewSyncClusterReader(ctx context.Context, opts *SyncReaderOptions) Reader {
-	addresses, _ := utils.GetRedisClusterNodes(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.PreferReplica)
+	addresses, _ := utils.GetRedisClusterNodes(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, opts.PreferReplica)
 	log.Debugf("get redis cluster nodes:")
 	for _, address := range addresses {
 		log.Debugf("%s", address)

--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,6 +34,7 @@ type SyncReaderOptions struct {
 	Username      string                 `mapstructure:"username" default:""`
 	Password      string                 `mapstructure:"password" default:""`
 	Tls           bool                   `mapstructure:"tls" default:"false"`
+	TlsConfig     client.TlsConfig       `mapstructure:"tls_config" default:"{}"`
 	SyncRdb       bool                   `mapstructure:"sync_rdb" default:"true"`
 	SyncAof       bool                   `mapstructure:"sync_aof" default:"true"`
 	PreferReplica bool                   `mapstructure:"prefer_replica" default:"false"`
@@ -111,7 +112,7 @@ type syncStandaloneReader struct {
 func NewSyncStandaloneReader(ctx context.Context, opts *SyncReaderOptions) Reader {
 	r := new(syncStandaloneReader)
 	r.opts = opts
-	r.client = client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.PreferReplica)
+	r.client = client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, opts.PreferReplica)
 	r.stat.Name = "reader_" + strings.Replace(opts.Address, ":", "_", -1)
 	r.stat.Address = opts.Address
 	r.stat.Status = kHandShake

--- a/internal/utils/cluster_nodes.go
+++ b/internal/utils/cluster_nodes.go
@@ -10,8 +10,8 @@ import (
 	"RedisShake/internal/log"
 )
 
-func GetRedisClusterNodes(ctx context.Context, address string, username string, password string, Tls bool, perferReplica bool) (addresses []string, slots [][]int) {
-	c := client.NewRedisClient(ctx, address, username, password, Tls, false)
+func GetRedisClusterNodes(ctx context.Context, address string, username string, password string, Tls bool, tlsConfig client.TlsConfig, perferReplica bool) (addresses []string, slots [][]int) {
+	c := client.NewRedisClient(ctx, address, username, password, Tls, tlsConfig, false)
 	reply := c.DoWithStringReply("cluster", "nodes")
 	reply = strings.TrimSpace(reply)
 	slotsCount := 0

--- a/internal/writer/redis_cluster_writer.go
+++ b/internal/writer/redis_cluster_writer.go
@@ -37,7 +37,7 @@ func (r *RedisClusterWriter) Close() {
 }
 
 func (r *RedisClusterWriter) loadClusterNodes(ctx context.Context, opts *RedisWriterOptions) {
-	addresses, slots := utils.GetRedisClusterNodes(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, false)
+	addresses, slots := utils.GetRedisClusterNodes(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, false)
 	r.addresses = addresses
 	for i, address := range addresses {
 		theOpts := *opts

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -18,13 +18,14 @@ import (
 )
 
 type RedisWriterOptions struct {
-	Cluster  bool                   `mapstructure:"cluster" default:"false"`
-	Address  string                 `mapstructure:"address" default:""`
-	Username string                 `mapstructure:"username" default:""`
-	Password string                 `mapstructure:"password" default:""`
-	Tls      bool                   `mapstructure:"tls" default:"false"`
-	OffReply bool                   `mapstructure:"off_reply" default:"false"`
-	Sentinel client.SentinelOptions `mapstructure:"sentinel"`
+	Cluster   bool                   `mapstructure:"cluster" default:"false"`
+	Address   string                 `mapstructure:"address" default:""`
+	Username  string                 `mapstructure:"username" default:""`
+	Password  string                 `mapstructure:"password" default:""`
+	Tls       bool                   `mapstructure:"tls" default:"false"`
+	TlsConfig client.TlsConfig       `mapstructure:"tls_config" default:"{}"`
+	OffReply  bool                   `mapstructure:"off_reply" default:"false"`
+	Sentinel  client.SentinelOptions `mapstructure:"sentinel"`
 }
 
 type redisStandaloneWriter struct {
@@ -49,7 +50,7 @@ func NewRedisStandaloneWriter(ctx context.Context, opts *RedisWriterOptions) Wri
 	rw := new(redisStandaloneWriter)
 	rw.address = opts.Address
 	rw.stat.Name = "writer_" + strings.Replace(opts.Address, ":", "_", -1)
-	rw.client = client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, false)
+	rw.client = client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, false)
 	rw.ch = make(chan *entry.Entry, config.Opt.Advanced.PipelineCountLimit)
 	if opts.OffReply {
 		log.Infof("turn off the reply of write")


### PR DESCRIPTION
Redis [mTLS](https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/)
Usage
```
[sync_reader]
cluster = false
address = "127.0.0.1:6379"

[redis_writer]
cluster = false
address = "127.0.0.1:6380"
tls = true

[redis_writer.tls_config]
ca_cert = "/etc/ssl/ca-cert.pem"
cert = "/etc/ssl/client.cert"
key = "/etc/ssl/client.key"
```