### PR TITLE
Use the correct function to avoid unnecessary formatting

### DIFF
--- a/internal/log/func.go
+++ b/internal/log/func.go
@@ -33,6 +33,6 @@ func Panicf(format string, args ...interface{}) {
 		}
 		errMsg += fmt.Sprintf("\n\t\t\t%v -> %n()", frameStr, frame)
 	}
-	logger.Error().Msgf(errMsg)
+	logger.Error().Msg(errMsg)
 	os.Exit(1)
 }


### PR DESCRIPTION
Change "logger.Error().Msgf(errMsg)" to "logger.Error().Msg(errMsg)"