### PR TITLE
Update cluster_nodes.go to handle hostnames in cluster nodes output

### DIFF
--- a/internal/utils/cluster_nodes.go
+++ b/internal/utils/cluster_nodes.go
@@ -32,6 +32,7 @@ func GetRedisClusterNodes(ctx context.Context, address string, username string, 
 
 		// address
 		address := strings.Split(words[1], "@")[0]
+		
 		// handle ipv6 address
 		tok := strings.Split(address, ":")
 		if len(tok) > 2 {
@@ -41,6 +42,13 @@ func GetRedisClusterNodes(ctx context.Context, address string, username string, 
 			ipv6Addr := strings.Join(tok[:len(tok)-1], ":")
 			address = fmt.Sprintf("[%s]:%s", ipv6Addr, port)
 		}
+		
+		// handle hostname
+		hostname := strings.Split(words[1],",")
+		if len(hostname) > 1 {
+                        address = fmt.Sprintf("%s:%s", hostname[1], tok[len(tok)-1])
+                }
+		
 		if isMaster && len(words) < 9 {
 			log.Warnf("the current master node does not hold any slots. address=[%v]", address)
 			continue


### PR DESCRIPTION
use hostname if present, else fallback to ipv6 address, else fallback to node ipv4 address

Detailed description: https://github.com/tair-opensource/RedisShake/issues/934

