### PR TITLE
Feat allow special cmd

### DIFF
--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -14,16 +14,14 @@ import (
 func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysIndexes []int) {
 	argc := len(argv)
 	group = "unknown"
-	originalName := argv[0]
-	cmaName = strings.ToUpper(argv[0])
-	inContainersCmd := false
-	if _, ok := containers[cmaName]; ok {
-		inContainersCmd = true
+	cmaName = argv[0]
+	upperCmaName := strings.ToUpper(argv[0])
+	if _, ok := containers[upperCmaName]; ok {
 		if len(argv) > 1 {
-			cmaName = fmt.Sprintf("%s-%s", cmaName, strings.ToUpper(argv[1]))
+			cmaName = fmt.Sprintf("%s-%s", upperCmaName, strings.ToUpper(argv[1]))
 		}
 	}
-	cmd, ok := redisCommands[cmaName]
+	cmd, ok := redisCommands[upperCmaName]
 	if !ok {
 		log.Warnf("unknown command. argv=%v", argv)
 		return
@@ -94,9 +92,6 @@ func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysI
 		}
 	}
 
-	if inContainersCmd == false {
-		cmaName = originalName
-	}
 	return
 }
 

--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -18,7 +18,7 @@ func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysI
 	upperCmaName := strings.ToUpper(argv[0])
 	if _, ok := containers[upperCmaName]; ok {
 		if len(argv) > 1 {
-			cmaName = fmt.Sprintf("%s-%s", upperCmaName, strings.ToUpper(argv[1]))
+			upperCmaName = fmt.Sprintf("%s-%s", upperCmaName, strings.ToUpper(argv[1]))
 		}
 	}
 	cmd, ok := redisCommands[upperCmaName]

--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -14,8 +14,11 @@ import (
 func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysIndexes []int) {
 	argc := len(argv)
 	group = "unknown"
+	originalName := argv[0]
 	cmaName = strings.ToUpper(argv[0])
+	inContainersCmd := false
 	if _, ok := containers[cmaName]; ok {
+		inContainersCmd = true
 		if len(argv) > 1 {
 			cmaName = fmt.Sprintf("%s-%s", cmaName, strings.ToUpper(argv[1]))
 		}
@@ -91,7 +94,9 @@ func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysI
 		}
 	}
 
-	cmaName = argv[0]
+	if inContainersCmd == false {
+		cmaName = originalName
+	}
 	return
 }
 

--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -90,6 +90,8 @@ func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysI
 			log.Panicf("wrong type: %s", spec.findKeysType)
 		}
 	}
+
+	cmaName = argv[0]
 	return
 }
 


### PR DESCRIPTION
该变动为了保留客户端原始命令，可以让使用者在aof_sync阶段，可以修改客户端输入的命令(大小写)来进行制定的过滤或者特殊处理，并且保留原逻辑中的根据大写命令来获取命令组相关信息能力

detail [#943](https://github.com/tair-opensource/RedisShake/issues/943)