### PR TITLE
增加限流功能

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,12 @@ require (
 	github.com/spf13/viper v1.18.1
 	github.com/stretchr/testify v1.8.4
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
+	go.uber.org/ratelimit v0.3.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -80,6 +82,8 @@ go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
+go.uber.org/ratelimit v0.3.1 h1:K4qVE+byfv/B3tC+4nYWP7v/6SimcO7HzHekoMNBma0=
+go.uber.org/ratelimit v0.3.1/go.mod h1:6euWsTB6U/Nb3X++xEUXA8ciPJvr19Q/0h1+oDcJhRk=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,12 @@
 package config
 
 import (
+	"RedisShake/internal/log"
 	"bytes"
 	"fmt"
 	"os"
 	"regexp"
 	"strings"
-
-	"RedisShake/internal/log"
 
 	"github.com/mcuadros/go-defaults"
 	"github.com/rs/zerolog"
@@ -62,6 +61,7 @@ type AdvancedOptions struct {
 	PipelineCountLimit              uint64 `mapstructure:"pipeline_count_limit" default:"1024"`
 	TargetRedisClientMaxQuerybufLen int64  `mapstructure:"target_redis_client_max_querybuf_len" default:"1024000000"`
 	TargetRedisProtoMaxBulkLen      uint64 `mapstructure:"target_redis_proto_max_bulk_len" default:"512000000"`
+	TargetRedisMaxQPS               int    `mapstructure:"target_redis_max_qps" default:"300000"`
 
 	AwsPSync string `mapstructure:"aws_psync" default:""` // 10.0.0.1:6379@nmfu2sl5osync,10.0.0.1:6379@xhma21xfkssync
 

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.uber.org/ratelimit"
 	"strconv"
 	"strings"
 	"sync"
@@ -99,6 +100,10 @@ func (w *redisStandaloneWriter) switchDbTo(newDbId int) {
 func (w *redisStandaloneWriter) processWrite(ctx context.Context) {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
+
+	var rl ratelimit.Limiter = nil
+	rl = ratelimit.New(config.Opt.Advanced.TargetRedisMaxQPS)
+	log.Infof("set target redis max qps to %d", config.Opt.Advanced.TargetRedisMaxQPS)
 	for {
 		select {
 		case <-ctx.Done():
@@ -121,6 +126,7 @@ func (w *redisStandaloneWriter) processWrite(ctx context.Context) {
 			for e.SerializedSize+atomic.LoadInt64(&w.stat.UnansweredBytes) > config.Opt.Advanced.TargetRedisClientMaxQuerybufLen {
 				time.Sleep(1 * time.Nanosecond)
 			}
+			rl.Take()
 			log.Debugf("[%s] send cmd. cmd=[%s]", w.stat.Name, e.String())
 			if !w.offReply {
 				select {

--- a/shake.toml
+++ b/shake.toml
@@ -131,6 +131,11 @@ rdb_restore_command_behavior = "panic" # panic, rewrite or skip
 # 1024 is a good default value for most cases.
 pipeline_count_limit = 1024
 
+# Use the token bucket rate limiting method to limit the maximum written QPS
+# If the performance of the target end is too poor or you want to protect the target redisyou can reduce this parameter
+# 300,000 is a maximum value. You can consider it as no rate limit
+target_redis_max_qps = 300000
+
 # This setting corresponds to the 'client-query-buffer-limit' in Redis configuration.
 # The default value is typically 1GB.
 # It's recommended not to modify this value unless absolutely necessary.


### PR DESCRIPTION
#854 中描述了目标性能过差情况下，会导致同步失败。虽然可以通过调整pipeline_count_limit参数来控制，但是不够精准。

场景：目标非redis，而是proxy+redis组合。一般proxy性能不如redis，在不限速情况下，会把单个proxy的cpu和延时都跑高，如目标端已有服务，会受到影响。

changelog:
通过引入ratelimit.Limiter，采用令牌桶方式进行写入限流，虽然会导致全量同步时间变长，但是可以很好的保护目标端。

feat:
想通过viper.WatchConfig实现热加载配置，但是测试未生效，未触发OnConfigChange函数。对这块不熟悉，暂未实现。