### PR TITLE
fix: use RESTORE command in RDB parser to respect rdb_restore_command_behavior

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,9 +55,12 @@ type AdvancedOptions struct {
 	// to change the default behavior of restore:
 	// panic:   redis-shake will stop when meet "Target key name is busy" error.
 	// rewrite: redis-shake will replace the key with new value.
-	// ignore:  redis-shake will skip restore the key when meet "Target key name is busy" error.
+	// skip:    redis-shake will skip restore the key when meet "Target key name is busy" error.
+	// Note: This configuration only applies to RDB parsing phase (rdb_reader and sync_reader RDB phase).
+	// For sync_reader's AOF phase, commands are forwarded directly without RESTORE.
+	// For large values exceeding target_redis_proto_max_bulk_len, RESTORE cannot be used,
+	// and individual commands will be used instead, which may not respect this setting.
 	RDBRestoreCommandBehavior string `mapstructure:"rdb_restore_command_behavior" default:"panic"`
-
 	PipelineCountLimit              uint64 `mapstructure:"pipeline_count_limit" default:"1024"`
 	TargetRedisClientMaxQuerybufLen int64  `mapstructure:"target_redis_client_max_querybuf_len" default:"1024000000"`
 	TargetRedisProtoMaxBulkLen      uint64 `mapstructure:"target_redis_proto_max_bulk_len" default:"512000000"`

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -10,13 +10,13 @@ import (
 	"strconv"
 	"time"
 
+	"RedisShake/internal/config"
 	"RedisShake/internal/entry"
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb/structure"
 	"RedisShake/internal/rdb/types"
 	"RedisShake/internal/utils"
 )
-
 const (
 	kFlagSlotInfo  = 244 // (Redis 7.4) RDB_OPCODE_SLOT_INFO: slot info
 	kFlagFunction2 = 245 // RDB_OPCODE_FUNCTION2: function library data
@@ -40,6 +40,32 @@ const (
 	kRDBModuleOpcodeDOUBLE = 4 // RDB_MODULE_OPCODE_DOUBLE: Double.
 	kRDBModuleOpcodeSTRING = 5 // RDB_MODULE_OPCODE_STRING: String.
 )
+
+// capturingReader is an io.Reader wrapper that captures all bytes read.
+// This is used to capture raw RDB value bytes for RESTORE command generation.
+type capturingReader struct {
+	rd     io.Reader
+	buffer bytes.Buffer
+}
+
+// Read implements io.Reader. It reads from the underlying reader and captures the bytes.
+func (cr *capturingReader) Read(p []byte) (n int, err error) {
+	n, err = cr.rd.Read(p)
+	if n > 0 {
+		cr.buffer.Write(p[:n])
+	}
+	return n, err
+}
+
+// Bytes returns the captured bytes.
+func (cr *capturingReader) Bytes() []byte {
+	return cr.buffer.Bytes()
+}
+
+// Reset clears the captured bytes.
+func (cr *capturingReader) Reset() {
+	cr.buffer.Reset()
+}
 
 type Loader struct {
 	replStreamDbId int // https://github.com/tair-opensource/RedisShake/pull/430#issuecomment-1099014464
@@ -210,20 +236,63 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 			return
 		default:
 			key := structure.ReadString(rd)
-			o := types.ParseObject(rd, typeByte, key, ld.isValkey)
+			// Use RESTORE command to properly handle duplicate key behavior (panic/skip/rewrite).
+			// This is controlled by the rdb_restore_command_behavior configuration.
+			// Note: For sync_reader's AOF phase, commands are forwarded directly without RESTORE,
+			// so this configuration only applies to RDB parsing phase.
+
+			// Capture raw value bytes using capturingReader
+			cr := &capturingReader{rd: rd}
+			o := types.ParseObject(cr, typeByte, key, ld.isValkey)
+			// Drain the Rewrite channel to ensure all value bytes are read
 			cmdC := o.Rewrite()
-			for cmd := range cmdC {
+			for range cmdC {
+			}
+
+			// Get captured value bytes (excluding the type byte that was already read)
+			valueBytes := cr.Bytes()
+
+			// Create RESTORE-compatible dump
+			dump := ld.createValueDump(typeByte, valueBytes)
+
+			// Check if dump size exceeds limit - if so, fall back to Rewrite commands
+			if uint64(len(dump)) > config.Opt.Advanced.TargetRedisProtoMaxBulkLen {
+				log.Warnf("key=[%s] dump len=[%d] exceeds target_redis_proto_max_bulk_len, falling back to individual commands. "+
+					"rdb_restore_command_behavior setting may not work correctly for this key.", key, len(dump))
+				// Parse again with the captured bytes (skip type byte, version, and CRC)
+				// The dump format is: type(1) + value + version(2) + crc(8)
+				valueOnly := valueBytes
+				anotherReader := bytes.NewReader(valueOnly)
+				o2 := types.ParseObject(anotherReader, typeByte, key, ld.isValkey)
+				cmdC2 := o2.Rewrite()
+				for cmd := range cmdC2 {
+					e := entry.NewEntry()
+					e.DbId = ld.nowDBId
+					e.Argv = cmd
+					ld.ch <- e
+				}
+				if ld.expireMs != 0 {
+					e := entry.NewEntry()
+					e.DbId = ld.nowDBId
+					e.Argv = []string{"PEXPIRE", key, strconv.FormatInt(ld.expireMs, 10)}
+					ld.ch <- e
+				}
+			} else {
+				// Use RESTORE command
+				pttl := 0
+				if ld.expireMs > 0 {
+					pttl = int(ld.expireMs)
+				}
+				argv := []string{"RESTORE", key, strconv.Itoa(pttl), dump}
+				if config.Opt.Advanced.RDBRestoreCommandBehavior == "rewrite" {
+					argv = append(argv, "replace")
+				}
 				e := entry.NewEntry()
 				e.DbId = ld.nowDBId
-				e.Argv = cmd
+				e.Argv = argv
 				ld.ch <- e
 			}
-			if ld.expireMs != 0 {
-				e := entry.NewEntry()
-				e.DbId = ld.nowDBId
-				e.Argv = []string{"PEXPIRE", key, strconv.FormatInt(ld.expireMs, 10)}
-				ld.ch <- e
-			}
+
 			ld.expireMs = 0
 			ld.idle = 0
 			ld.freq = 0

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -1,0 +1,68 @@
+package rdb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapturingReader(t *testing.T) {
+	// Test that capturingReader captures all bytes read
+	input := []byte("hello world")
+	cr := &capturingReader{rd: bytes.NewReader(input)}
+
+	buf := make([]byte, len(input))
+	n, err := cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, len(input), n)
+	require.Equal(t, input, buf)
+	require.Equal(t, input, cr.Bytes())
+}
+
+func TestCapturingReader_MultipleReads(t *testing.T) {
+	// Test that capturingReader captures bytes across multiple reads
+	input := []byte("hello world")
+	cr := &capturingReader{rd: bytes.NewReader(input)}
+
+	// Read in small chunks
+	buf := make([]byte, 5)
+	n, err := cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, []byte("hello"), buf)
+
+	n, err = cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, []byte(" worl"), buf)
+
+	// Last read
+	buf = make([]byte, 5)
+	n, err = cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, []byte("d"), buf[:n])
+
+	// Check captured bytes
+	require.Equal(t, input, cr.Bytes())
+}
+
+func TestCapturingReader_Reset(t *testing.T) {
+	input := []byte("hello world")
+	cr := &capturingReader{rd: bytes.NewReader(input)}
+
+	buf := make([]byte, len(input))
+	cr.Read(buf)
+	require.Equal(t, input, cr.Bytes())
+
+	cr.Reset()
+	require.Equal(t, 0, len(cr.Bytes()))
+}
+
+func TestCapturingReader_Empty(t *testing.T) {
+	cr := &capturingReader{rd: bytes.NewReader([]byte{})}
+	// Bytes() returns nil when buffer is empty, which is fine
+	// Both nil and empty slice represent "no bytes captured"
+	require.True(t, len(cr.Bytes()) == 0 || cr.Bytes() == nil)
+}

--- a/shake.toml
+++ b/shake.toml
@@ -121,9 +121,12 @@ log_compress = true    # enable log compression after rotate, default true
 # to change the default behavior of restore:
 # panic:   redis-shake will stop when meet "Target key name is busy" error.
 # rewrite: redis-shake will replace the key with new value.
-# skip:  redis-shake will skip restore the key when meet "Target key name is busy" error.
+# skip:    redis-shake will skip restore the key when meet "Target key name is busy" error.
+# Note: This configuration only applies to RDB parsing phase (rdb_reader and sync_reader RDB phase).
+# For sync_reader's AOF phase, commands are forwarded directly without RESTORE.
+# For large values exceeding target_redis_proto_max_bulk_len, RESTORE cannot be used,
+# and individual commands will be used instead, which may not respect this setting.
 rdb_restore_command_behavior = "panic" # panic, rewrite or skip
-
 # redis-shake uses pipeline to improve sending performance.
 # Adjust this value based on the destination Redis performance:
 # - Higher values may improve performance for capable destinations.


### PR DESCRIPTION
## Summary

- Fix RDB parser to use RESTORE command instead of individual commands (SET, HSET, RPUSH, etc.) to properly respect the `rdb_restore_command_behavior` configuration
- Add `capturingReader` to capture raw RDB value bytes for RESTORE command generation
- Add fallback to individual commands for large values exceeding `target_redis_proto_max_bulk_len` with warning log
- Update documentation to clarify that `rdb_restore_command_behavior` only applies to RDB parsing phase

## Problem

The `rdb_restore_command_behavior` config (values: panic/skip/rewrite) was not being respected in RDB mode because:

1. RDB parser called `o.Rewrite()` which generates individual commands like `SET`, `HSET`, `RPUSH`
2. These commands silently overwrite existing keys without triggering BUSYKEY error
3. The config only works when RESTORE command is used (which triggers BUSYKEY error when key exists)

## Solution

1. Capture raw RDB value bytes using a `capturingReader` wrapper
2. Create RESTORE-compatible dump with proper format (type + value + version + CRC)
3. Send RESTORE command instead of individual commands
4. For large values exceeding `target_redis_proto_max_bulk_len`, fall back to individual commands with warning

## Notes

- This configuration only applies to RDB parsing phase (rdb_reader and sync_reader RDB phase)
- For sync_reader's AOF phase, commands are forwarded directly without RESTORE
- For large values exceeding `target_redis_proto_max_bulk_len`, RESTORE cannot be used, and individual commands will be used instead (with a warning log)

Fixes #996