### PR TITLE
ci: add weekly scheduled run to keep caches warm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [ v4 ]
     workflow_dispatch:
+    # Schedule weekly cache refresh to prevent cache expiration (7-day limit)
+    schedule:
+        - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
 
 jobs:
     redis-test:
@@ -81,6 +84,8 @@ jobs:
                 run: sh build.sh
 
             -   name: Run tests
+                # Skip tests for scheduled runs (only refresh cache)
+                if: github.event_name != 'schedule'
                 run: sh test.sh
 
     valkey-test:
@@ -132,6 +137,8 @@ jobs:
                 run: sh build.sh
 
             -   name: Run tests
+                # Skip tests for scheduled runs (only refresh cache)
+                if: github.event_name != 'schedule'
                 run: |
                     go test ./... -v
                     cd tests/ && pybbt cases --verbose


### PR DESCRIPTION
## Summary
- Add weekly scheduled CI run (every Sunday 00:00 UTC) to refresh caches
- Skip test execution for scheduled runs, only build and cache dependencies
- Prevents cache expiration after 7 days of non-use

## Why
GitHub Actions cache expires after 7 days of non-use. This means:
1. PRs from branches within the same repo may need to rebuild Redis/Valkey if no CI ran on v4 for a week
2. A weekly refresh ensures caches are always available

## Note
PRs from forks still cannot access the base repository's cache due to GitHub security restrictions. This optimization primarily helps PRs from branches within the same repository.

## Test plan
- [ ] Verify scheduled run triggers correctly
- [ ] Verify cache is properly refreshed
- [ ] Verify test runs still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)