### PR TITLE
fix: discard RDB data when sync_rdb=false instead of writing to disk

### DIFF
--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -338,6 +338,21 @@ func (r *syncStandaloneReader) receiveRDB() string {
 	}
 	marker = strings.TrimSpace(marker)
 
+	r.stat.Status = kReceiveRdb
+
+	// When sync_rdb is disabled, we still must receive the RDB payload from the source
+	// (required by Redis replication protocol), but we discard it instead of writing to disk.
+	if !r.opts.SyncRdb {
+		log.Infof("[%s] sync_rdb is disabled. Receiving and discarding RDB payload (required by replication protocol).", r.stat.Name)
+		if strings.HasPrefix(marker, "EOF") {
+			r.receiveRDBWithDiskless(marker, io.Discard)
+		} else {
+			r.receiveRDBWithoutDiskless(marker, io.Discard)
+		}
+		log.Infof("[%s] RDB payload discarded. timeUsed=[%.2f]s", r.stat.Name, time.Since(timeStart).Seconds())
+		return ""
+	}
+
 	// create rdb file
 	rdbFilePath, err := filepath.Abs(r.stat.Name + "/dump.rdb")
 	if err != nil {
@@ -351,7 +366,6 @@ func (r *syncStandaloneReader) receiveRDB() string {
 	}
 
 	// receive rdb
-	r.stat.Status = kReceiveRdb
 	if strings.HasPrefix(marker, "EOF") {
 		log.Infof("[%s] source db supoort diskless sync capability.", r.stat.Name)
 		r.receiveRDBWithDiskless(marker, rdbFileHandle)

--- a/tests/cases/aof.py
+++ b/tests/cases/aof.py
@@ -1,9 +1,11 @@
-import pybbt as p
-
-import helpers as h
 import os
 import time
-#format aof command
+
+import pybbt
+
+import helpers as h
+
+
 def format_command(*args):
     cmd = f"*{len(args)}\r\n"
     for a in args:
@@ -12,15 +14,17 @@ def format_command(*args):
 
 
 def append_to_file(write_file, strings):
-     with open(write_file, "w+") as fp:
+    with open(write_file, "w+") as fp:
         for string in strings:
             fp.write(string)
+
 
 def create_aof_dir(dir_path):
     os.makedirs(dir_path, exist_ok=True)
 
+
 def get_aof_file_relative_path():
-    if h.REDIS_SERVER_VERSION  >= 7.0:
+    if h.REDIS_SERVER_VERSION >= 7.0:
         aof_file = "/appendonlydir/appendonly.aof.manifest"
     else:
         aof_file = "/appendonly.aof"
@@ -51,7 +55,7 @@ def wait_for_aof_ready(src, timeout=15):
         if os.path.exists(aof_file_path):
             file_size = os.path.getsize(aof_file_path)
             if file_size > 0 and not rewrite_in_progress:
-                p.log(f"aof ready: {aof_file_path}, size={file_size}")
+                pybbt.log(f"aof ready: {aof_file_path}, size={file_size}")
                 return aof_file_path
 
         if time.time() - begin > timeout:
@@ -74,145 +78,135 @@ def get_base_file_from_manifest(manifest_path):
                 return os.path.join(os.path.dirname(manifest_path), parts[1])
     return None
 
-def test(src, dst):
+
+def _test_aof(src, dst):
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_TRUE(src.do("save"))
+    pybbt.ASSERT_TRUE(src.do("save"))
     wait_for_aof_ready(src)
 
     opts = h.ShakeOpts.create_aof_opts(f"{src.dir}{get_aof_file_relative_path()}", dst)
     h.Shake.run_once(opts)
     # check data
     inserter.check_data(dst, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_EQ(src.dbsize(), dst.dbsize())
+    pybbt.ASSERT_EQ(src.dbsize(), dst.dbsize())
 
-def test_base_file(dst):
-    #creat manifest file
-    current_directory = p.get_case_context().dir  + "_own"
+
+def _test_base_file(dst):
+    current_directory = pybbt.get_case_context().dir + "_own"
     create_aof_dir(current_directory + "/appendonlydir")
     manifest_filepath = current_directory + "/appendonlydir/appendonly.aof.manifest"
     commands = []
     commands += "file appendonly.aof.1.base.aof seq 1 type b\n"
     append_to_file(manifest_filepath, commands)
 
-    #creat aof file
     base_file_path = current_directory + "/appendonlydir/appendonly.aof.1.base.aof"
     commands = []
-    commands  += format_command("set", "k1", "v1")
-    commands  += format_command("set", "k2", "v2")
+    commands += format_command("set", "k1", "v1")
+    commands += format_command("set", "k2", "v2")
     append_to_file(base_file_path, commands)
 
-    #start shake redis
     opts = h.ShakeOpts.create_aof_opts(f"{current_directory}{get_aof_file_relative_path()}", dst)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     h.Shake.run_once(opts)
 
-    #check data
     pip = dst.pipeline()
     pip.get("k1")
     pip.get("k2")
     ret = pip.execute()
-    p.ASSERT_EQ(ret, [b"v1", b"v2"])
-    p.ASSERT_EQ(dst.dbsize(), 2)
+    pybbt.ASSERT_EQ(ret, [b"v1", b"v2"])
+    pybbt.ASSERT_EQ(dst.dbsize(), 2)
 
 
-def test_error(src, dst):
-    #set aof
+def _test_error(src, dst):
     ret = src.do("CONFIG SET", "appendonly", "yes")
-    p.log(f"aof_ret: {ret}")
+    pybbt.log(f"aof_ret: {ret}")
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_TRUE(src.do("save"))
+    pybbt.ASSERT_TRUE(src.do("save"))
     wait_for_aof_ready(src)
-    #destroy file
+    # destroy file
     file_path = get_aof_file_path(src)
     with open(file_path, "r+") as file:
         destroy_data = "xxxxs"
         file.seek(0, 0)
         file.write(destroy_data)
 
-
     opts = h.ShakeOpts.create_aof_opts(f"{src.dir}/appendonlydir/appendonly.aof.manifest", dst)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     h.Shake.run_once(opts)
 
-    #cant restore
-    p.ASSERT_EQ( dst.dbsize(), 0)
+    # cant restore
+    pybbt.ASSERT_EQ(dst.dbsize(), 0)
 
 
-
-def test_rm_file(src, dst):
+def _test_rm_file(src, dst):
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_TRUE(src.do("save"))
+    pybbt.ASSERT_TRUE(src.do("save"))
     manifest_path = wait_for_aof_ready(src)
-    #rm file
+    # rm file
     file_path = get_base_file_from_manifest(manifest_path)
-    p.ASSERT_TRUE(file_path is not None)
-    p.log(f"remove aof base file: {file_path}")
+    pybbt.ASSERT_TRUE(file_path is not None)
+    pybbt.log(f"remove aof base file: {file_path}")
     os.remove(file_path)
     opts = h.ShakeOpts.create_aof_opts(f"{src.dir}{get_aof_file_relative_path()}", dst)
     h.Shake.run_once(opts)
-    #cant restore
-    p.ASSERT_EQ(dst.dbsize(), 0)
+    # cant restore
+    pybbt.ASSERT_EQ(dst.dbsize(), 0)
 
-def test_history_file(src, dst):
 
+def _test_history_file(src, dst):
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
-    for i in  range(1000):
+    for i in range(1000):
         inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_TRUE(src.do("BGREWRITEAOF"))
+    pybbt.ASSERT_TRUE(src.do("BGREWRITEAOF"))
 
     opts = h.ShakeOpts.create_aof_opts(f"{src.dir}{get_aof_file_relative_path()}", dst)
     h.Shake.run_once(opts)
     # check data
     inserter.check_data(dst, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_EQ(src.dbsize(), dst.dbsize())
+    pybbt.ASSERT_EQ(src.dbsize(), dst.dbsize())
 
 
-def test_base_file_timestamp(dst): # base file play back all
-    #creat manifest file
-    current_directory = p.get_case_context().dir + "_own"
+def _test_base_file_timestamp(dst):
+    current_directory = pybbt.get_case_context().dir + "_own"
     create_aof_dir(current_directory)
     manifest_filepath = current_directory + "/appendonlydir/appendonly.aof.manifest"
     commands = []
     commands += "file appendonly.aof.1.base.aof seq 1 type b\n"
     append_to_file(manifest_filepath, commands)
 
-    #creat aof file
     base_file_path = current_directory + "/appendonlydir/appendonly.aof.1.base.aof"
     commands = []
-    commands  += "#TS1233\r\n"
-    commands  += format_command("set", "k1", "v1")
-    commands  += "#TS1234\r\n"
-    commands  += format_command("set", "k2", "v2")
-    commands  += "#TS1235\r\n"
-    commands  += format_command("set", "k3", "v3")
+    commands += "#TS1233\r\n"
+    commands += format_command("set", "k1", "v1")
+    commands += "#TS1234\r\n"
+    commands += format_command("set", "k2", "v2")
+    commands += "#TS1235\r\n"
+    commands += format_command("set", "k3", "v3")
     append_to_file(base_file_path, commands)
 
-    #start shake redis
     opts = h.ShakeOpts.create_aof_opts(f"{current_directory}{get_aof_file_relative_path()}", dst, 1234)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     h.Shake.run_once(opts)
 
-    #check data
     pip = dst.pipeline()
     pip.get("k1")
     pip.get("k2")
     pip.get("k3")
     ret = pip.execute()
-    p.ASSERT_EQ(ret, [b"v1",b"v2",b"v3",])
-    p.ASSERT_EQ(dst.dbsize(), 3)
+    pybbt.ASSERT_EQ(ret, [b"v1", b"v2", b"v3"])
+    pybbt.ASSERT_EQ(dst.dbsize(), 3)
 
-def test_base_and_incr_timestamp(dst):
 
-    #creat manifest file
-    current_directory = p.get_case_context().dir + "_own"
+def _test_base_and_incr_timestamp(dst):
+    current_directory = pybbt.get_case_context().dir + "_own"
     create_aof_dir(current_directory + "/appendonlydir")
     manifest_filepath = current_directory + "/appendonlydir/appendonly.aof.manifest"
     commands = []
@@ -221,140 +215,124 @@ def test_base_and_incr_timestamp(dst):
     commands += "file appendonly.aof.2.incr.aof seq 2 type i\n"
     append_to_file(manifest_filepath, commands)
 
-    #creat aof base file
     base_file_path = current_directory + "/appendonlydir/appendonly.aof.1.base.aof"
     commands = []
-    commands  += format_command("set", "k1", "v1")
+    commands += format_command("set", "k1", "v1")
     append_to_file(base_file_path, commands)
 
     commands = []
-    #create aof incr file
     incr1_file_path = current_directory + "/appendonlydir/appendonly.aof.1.incr.aof"
-    commands  += "#TS1233\r\n"
-    commands  += format_command("set", "k2", "v2")
-    append_to_file(incr1_file_path , commands)
+    commands += "#TS1233\r\n"
+    commands += format_command("set", "k2", "v2")
+    append_to_file(incr1_file_path, commands)
 
     commands = []
     incr2_file_path = current_directory + "/appendonlydir/appendonly.aof.2.incr.aof"
-    commands  += "#TS1235\r\n"
-    commands  += format_command("set", "k3", "v3")
-    append_to_file(incr2_file_path , commands)
-    #start shake redis
+    commands += "#TS1235\r\n"
+    commands += format_command("set", "k3", "v3")
+    append_to_file(incr2_file_path, commands)
+
     opts = h.ShakeOpts.create_aof_opts(f"{current_directory}{get_aof_file_relative_path()}", dst, 1234)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     h.Shake.run_once(opts)
 
-    #check data
     pip = dst.pipeline()
     pip.get("k1")
     pip.get("k2")
     ret = pip.execute()
-    p.ASSERT_EQ(ret, [b"v1",b"v2"])
-    p.ASSERT_EQ(dst.dbsize(), 2)
+    pybbt.ASSERT_EQ(ret, [b"v1", b"v2"])
+    pybbt.ASSERT_EQ(dst.dbsize(), 2)
 
 
+# Temporarily disabled: AOF reader tests.
+
+@pybbt.case(skip=True)
 def aof_to_standalone():
     if h.REDIS_SERVER_VERSION < 7.0:
         return
     src = h.Redis()
-    #set aof
     ret = src.do("CONFIG SET", "appendonly", "yes")
-    p.log(f"aof_ret: {ret}")
-
+    pybbt.log(f"aof_ret: {ret}")
     ret = src.do("CONFIG SET", "aof-timestamp-enabled", "yes")
-    p.log(f"aof_ret: {ret}")
+    pybbt.log(f"aof_ret: {ret}")
     dst = h.Redis()
-    test(src, dst)
+    _test_aof(src, dst)
 
+
+@pybbt.case(skip=True)
 def aof_to_standalone_base_file():
     if h.REDIS_SERVER_VERSION < 7.0:
         return
     dst = h.Redis()
-    test_base_file(dst)
+    _test_base_file(dst)
 
 
-def aof_to_standalone_rm_file():
-    if h.REDIS_SERVER_VERSION < 7.0:
-        return
-    src = h.Redis()
-    #set aof
-    ret = src.do("CONFIG SET", "appendonly", "yes")
-    dst = h.Redis()
-    test_rm_file(src, dst)
-
-def aof_to_standalone_error():
-    if h.REDIS_SERVER_VERSION < 7.0:
-        return
-    src = h.Redis()
-    #set aof
-    ret = src.do("CONFIG SET", "appendonly", "yes")
-    dst = h.Redis()
-    test_error(src, dst)
-
-def aof_to_cluster():
-    if h.REDIS_SERVER_VERSION < 7.0:
-        return
-    src = h.Redis()
-    #set aof
-    ret = src.do("CONFIG SET", "appendonly", "yes")
-    p.log(f"aof_ret: {ret}")
-    dst = h.Cluster()
-    test(src, dst)
-
+@pybbt.case(skip=True)
 def aof_to_standalone_single():
     if h.REDIS_SERVER_VERSION >= 7.0:
         return
     src = h.Redis()
-    #set preamble no
     ret = src.do("CONFIG SET", "aof-use-rdb-preamble", "no")
-    p.log(f"aof_ret: {ret}")
-    #set aof
+    pybbt.log(f"aof_ret: {ret}")
     ret = src.do("CONFIG SET", "appendonly", "yes")
-    p.log(f"aof_ret: {ret}")
+    pybbt.log(f"aof_ret: {ret}")
     dst = h.Redis()
-    test(src, dst)
+    _test_aof(src, dst)
 
+
+@pybbt.case(skip=True)
+def aof_to_standalone_error():
+    if h.REDIS_SERVER_VERSION < 7.0:
+        return
+    src = h.Redis()
+    ret = src.do("CONFIG SET", "appendonly", "yes")
+    dst = h.Redis()
+    _test_error(src, dst)
+
+
+@pybbt.case(skip=True)
+def aof_to_standalone_rm_file():
+    if h.REDIS_SERVER_VERSION < 7.0:
+        return
+    src = h.Redis()
+    ret = src.do("CONFIG SET", "appendonly", "yes")
+    dst = h.Redis()
+    _test_rm_file(src, dst)
+
+
+@pybbt.case(skip=True)
+def aof_to_cluster():
+    if h.REDIS_SERVER_VERSION < 7.0:
+        return
+    src = h.Redis()
+    ret = src.do("CONFIG SET", "appendonly", "yes")
+    pybbt.log(f"aof_ret: {ret}")
+    dst = h.Cluster()
+    _test_aof(src, dst)
+
+
+@pybbt.case(skip=True)
 def aof_to_standalone_timestamp():
     if h.REDIS_SERVER_VERSION < 7.0:
         return
     dst = h.Redis()
-
     ret = dst.do("FLUSHALL")
-    test_base_file_timestamp(dst)
+    _test_base_file_timestamp(dst)
     ret = dst.do("FLUSHALL")
-    test_base_and_incr_timestamp(dst)
+    _test_base_and_incr_timestamp(dst)
     ret = dst.do("FLUSHALL")
 
-def aof_to_standalone_history_file():
-    if h.REDIS_SERVER_VERSION < 7.0:
-        return
-    src = h.Redis()
-    #set aof
-    #set hist
-    ret = src.do("CONFIG SET", "aof-disable-auto-gc", "yes")
-    p.log(f"aof_ret: {ret}")
 
-    ret = src.do("CONFIG SET", "appendonly", "yes")
-    p.log(f"aof_ret: {ret}")
-
-    ret = src.do("CONFIG SET", "aof-timestamp-enabled", "yes")
-    p.log(f"aof_ret: {ret}")
-
-    dst = h.Redis()
-    test_history_file(src, dst)
-
-# Temporarily disabled: AOF reader test entry.
-@p.case(skip=True)
-def main():
-    aof_to_standalone() # base + incr aof-multi
-    aof_to_standalone_base_file() # base file aof-multi
-    aof_to_standalone_single() #single aof
-    aof_to_standalone_error() # error aof file
-    aof_to_standalone_rm_file() # rm aof file
-    # aof_to_standalone_history_file() # history + incr aof-multi
-    aof_to_cluster() #test cluster
-    aof_to_standalone_timestamp() #set timestamp aof-multi
-
-
-if __name__ == '__main__':
-    main()
+# @pybbt.case(skip=True)
+# def aof_to_standalone_history_file():
+#     if h.REDIS_SERVER_VERSION < 7.0:
+#         return
+#     src = h.Redis()
+#     ret = src.do("CONFIG SET", "aof-disable-auto-gc", "yes")
+#     pybbt.log(f"aof_ret: {ret}")
+#     ret = src.do("CONFIG SET", "appendonly", "yes")
+#     pybbt.log(f"aof_ret: {ret}")
+#     ret = src.do("CONFIG SET", "aof-timestamp-enabled", "yes")
+#     pybbt.log(f"aof_ret: {ret}")
+#     dst = h.Redis()
+#     _test_history_file(src, dst)

--- a/tests/cases/auth_acl.py
+++ b/tests/cases/auth_acl.py
@@ -1,9 +1,13 @@
-import pybbt as p
+import pybbt
 
 import helpers as h
 
 
-def acl():
+@pybbt.case()
+def test_acl():
+    if h.REDIS_SERVER_VERSION < 6.0:
+        return
+
     src = h.Redis()
     dst = h.Redis()
 
@@ -23,26 +27,14 @@ def acl():
     opts["sync_reader"]["password"] = "password0"
     opts["redis_writer"]["username"] = "user1"
     opts["redis_writer"]["password"] = "password1"
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     shake = h.Shake(opts)
 
     # wait sync done
     shake.wait_for_sync(timeout=10)
-    p.log(shake.get_status())
+    pybbt.log(shake.get_status())
 
     # check data
     inserter.check_data(src, cross_slots_cmd=True)
     inserter.check_data(dst, cross_slots_cmd=True)
-    p.ASSERT_EQ(src.dbsize(), dst.dbsize())
-
-
-@p.case()
-def main():
-    if h.REDIS_SERVER_VERSION < 6.0:
-        return
-
-    acl()
-
-
-if __name__ == '__main__':
-    main()
+    pybbt.ASSERT_EQ(src.dbsize(), dst.dbsize())

--- a/tests/cases/function.py
+++ b/tests/cases/function.py
@@ -1,8 +1,10 @@
+import pybbt
+
 import helpers as h
-import pybbt as p
 
 
-def filter_db():
+@pybbt.case()
+def test_filter_db():
     src = h.Redis()
     dst = h.Redis()
 
@@ -16,7 +18,7 @@ def filter_db():
         end
         shake.call(DB, ARGV)
     """
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     shake = h.Shake(opts)
 
     for db in range(16):
@@ -27,13 +29,14 @@ def filter_db():
     shake.wait_for_sync(timeout=10, db=1)
 
     dst.do("select", 0)
-    p.ASSERT_EQ(dst.do("get", "key"), None)
+    pybbt.ASSERT_EQ(dst.do("get", "key"), None)
     for db in range(1, 16):
         dst.do("select", db)
-        p.ASSERT_EQ(dst.do("get", "key"), b"value")
+        pybbt.ASSERT_EQ(dst.do("get", "key"), b"value")
 
 
-def split_mset_to_set():
+@pybbt.case()
+def test_split_mset_to_set():
     src = h.Redis()
     dst = h.Redis()
     opts = h.ShakeOpts.create_sync_opts(src, dst)
@@ -48,7 +51,7 @@ def split_mset_to_set():
             end
         end
     """
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     shake = h.Shake(opts)
     src.do("mset", "k1", "v1", "k2", "v2", "k3", "v3")
 
@@ -61,20 +64,10 @@ def split_mset_to_set():
         return dst.do("get", "k1") == b"v1"
 
     try:
-        p.ASSERT_TRUE_TIMEOUT(data_synced, timeout=10, interval=0.01)
+        pybbt.ASSERT_TRUE_TIMEOUT(data_synced, timeout=10, interval=0.01)
     except Exception as e:
         with open(f"{shake.dir}/data/shake.log") as f:
-            p.log(f.read())
+            pybbt.log(f.read())
         raise e
-    p.ASSERT_EQ(dst.do("get", "k2"), b"v2")
-    p.ASSERT_EQ(dst.do("get", "k3"), b"v3")
-
-
-@p.case()
-def main():
-    filter_db()
-    split_mset_to_set()
-
-
-if __name__ == '__main__':
-    main()
+    pybbt.ASSERT_EQ(dst.do("get", "k2"), b"v2")
+    pybbt.ASSERT_EQ(dst.do("get", "k3"), b"v3")

--- a/tests/cases/rdb.py
+++ b/tests/cases/rdb.py
@@ -1,43 +1,35 @@
-import pybbt as p
+import pybbt
 
 import helpers as h
 
 
-def test(src, dst):
+def _test_rdb(src, dst):
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_TRUE(src.do("save"))
+    pybbt.ASSERT_TRUE(src.do("save"))
 
     opts = h.ShakeOpts.create_rdb_opts(f"{src.dir}/dump.rdb", dst)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     h.Shake.run_once(opts)
 
     # check data
     inserter.check_data(src, cross_slots_cmd=cross_slots_cmd)
     inserter.check_data(dst, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_EQ(src.dbsize(), dst.dbsize())
+    pybbt.ASSERT_EQ(src.dbsize(), dst.dbsize())
 
 
+@pybbt.case()
 def rdb_to_standalone():
     src = h.Redis()
     dst = h.Redis()
-    test(src, dst)
+    _test_rdb(src, dst)
 
 
+@pybbt.case()
 def rdb_to_cluster():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Redis()
     dst = h.Cluster()
-    test(src, dst)
-
-
-@p.case()
-def main():
-    rdb_to_standalone()
-    rdb_to_cluster()
-
-
-if __name__ == '__main__':
-    main()
+    _test_rdb(src, dst)

--- a/tests/cases/scan.py
+++ b/tests/cases/scan.py
@@ -1,17 +1,17 @@
-import pybbt as p
+import pybbt
 
 import helpers as h
 
 
-def test(src, dst):
+def _test_scan(src, dst):
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_TRUE(src.do("save"))
+    pybbt.ASSERT_TRUE(src.do("save"))
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)  # add data again
 
     opts = h.ShakeOpts.create_scan_opts(src, dst)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
 
     # run shake
     h.Shake.run_once(opts)
@@ -19,46 +19,38 @@ def test(src, dst):
     # check data
     inserter.check_data(src, cross_slots_cmd=cross_slots_cmd)
     inserter.check_data(dst, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_EQ(src.dbsize(), dst.dbsize())
+    pybbt.ASSERT_EQ(src.dbsize(), dst.dbsize())
 
 
+@pybbt.case()
 def standalone_to_standalone():
     src = h.Redis()
     dst = h.Redis()
-    test(src, dst)
+    _test_scan(src, dst)
 
 
+@pybbt.case()
 def standalone_to_cluster():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Redis()
     dst = h.Cluster()
-    test(src, dst)
+    _test_scan(src, dst)
 
 
+@pybbt.case()
 def cluster_to_standalone():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Cluster()
     dst = h.Redis()
-    test(src, dst)
+    _test_scan(src, dst)
 
 
+@pybbt.case()
 def cluster_to_cluster():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Cluster()
     dst = h.Cluster()
-    test(src, dst)
-
-
-@p.case()
-def main():
-    standalone_to_standalone()
-    standalone_to_cluster()
-    cluster_to_standalone()
-    cluster_to_cluster()
-
-
-if __name__ == '__main__':
-    main()
+    _test_scan(src, dst)

--- a/tests/cases/sync.py
+++ b/tests/cases/sync.py
@@ -1,17 +1,21 @@
-import pybbt as p
+import os
+import time
+
+import pybbt
 
 import helpers as h
+from helpers.utils.timer import Timer
 
 
-def test(src, dst):
+def _test_sync(src, dst):
     cross_slots_cmd = not (src.is_cluster() or dst.is_cluster())
     inserter = h.DataInserter()
     inserter.add_data(src, cross_slots_cmd=cross_slots_cmd)
 
-    p.ASSERT_TRUE(src.do("save"))
+    pybbt.ASSERT_TRUE(src.do("save"))
 
     opts = h.ShakeOpts.create_sync_opts(src, dst)
-    p.log(f"opts: {opts}")
+    pybbt.log(f"opts: {opts}")
     shake = h.Shake(opts)
 
     # Use longer timeout for cluster sync (cluster gossip and cross-node sync takes more time)
@@ -22,7 +26,7 @@ def test(src, dst):
         shake.wait_for_sync(timeout=sync_timeout)
     except Exception as e:
         with open(f"{shake.dir}/data/shake.log") as f:
-            p.log(f.read())
+            pybbt.log(f.read())
         raise e
 
     # add data again
@@ -30,51 +34,112 @@ def test(src, dst):
 
     # wait sync done
     shake.wait_for_sync(timeout=sync_timeout)
-    p.log(shake.get_status())
+    pybbt.log(shake.get_status())
 
     # check data
     inserter.check_data(src, cross_slots_cmd=cross_slots_cmd)
     inserter.check_data(dst, cross_slots_cmd=cross_slots_cmd)
-    p.ASSERT_EQ(src.dbsize(), dst.dbsize())
+    pybbt.ASSERT_EQ(src.dbsize(), dst.dbsize())
 
 
+@pybbt.case()
 def standalone_to_standalone():
     src = h.Redis()
     dst = h.Redis()
-    test(src, dst)
+    _test_sync(src, dst)
 
 
+@pybbt.case()
 def standalone_to_cluster():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Redis()
     dst = h.Cluster()
-    test(src, dst)
+    _test_sync(src, dst)
 
 
+@pybbt.case()
 def cluster_to_standalone():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Cluster()
     dst = h.Redis()
-    test(src, dst)
+    _test_sync(src, dst)
 
 
+@pybbt.case()
 def cluster_to_cluster():
     if h.REDIS_SERVER_VERSION < 3.0:
         return
     src = h.Cluster()
     dst = h.Cluster()
-    test(src, dst)
+    _test_sync(src, dst)
 
 
-@p.case()
-def main():
-    standalone_to_standalone()
-    standalone_to_cluster()
-    cluster_to_standalone()
-    cluster_to_cluster()
+@pybbt.case()
+def test_sync_rdb_false():
+    """Test that sync_rdb=false discards RDB (no dump.rdb on disk) and only syncs AOF."""
+    src = h.Redis()
+    dst = h.Redis()
 
+    # Insert data before sync — this will be part of the RDB snapshot
+    rdb_keys = {"sync_rdb_false:rdb_key1": "value1", "sync_rdb_false:rdb_key2": "value2"}
+    for k, v in rdb_keys.items():
+        src.do("set", k, v)
+    src.do("save")
+    pybbt.log(f"src dbsize after RDB data: {src.dbsize()}")
 
-if __name__ == '__main__':
-    main()
+    # Start shake with sync_rdb=false
+    opts = h.ShakeOpts.create_sync_opts(src, dst)
+    opts["sync_reader"]["sync_rdb"] = False
+    pybbt.log(f"opts: {opts}")
+    shake = h.Shake(opts)
+
+    # Wait for shake to finish RDB phase and become consistent
+    timer = Timer()
+    while not shake.is_consistent():
+        if timer.elapsed() > 10:
+            with open(f"{shake.dir}/data/shake.log") as f:
+                pybbt.log(f.read())
+            raise TimeoutError("shake not consistent within 10s")
+        time.sleep(0.1)
+    pybbt.log("shake is consistent after RDB phase skipped")
+
+    # Core assertion: no dump.rdb file should exist on disk.
+    # Before the fix, receiveRDB() always wrote RDB to disk even when sync_rdb=false.
+    status = shake.get_status()
+    reader_dir = status["reader"]["dir"]
+    rdb_file = os.path.join(reader_dir, "dump.rdb")
+    pybbt.ASSERT_FALSE(os.path.exists(rdb_file))
+    pybbt.log(f"verified: no dump.rdb on disk at {rdb_file}")
+
+    # Verify RDB data is NOT in dst
+    for k in rdb_keys:
+        pybbt.ASSERT_EQ(dst.do("get", k), None)
+    pybbt.ASSERT_EQ(dst.dbsize(), 0)
+    pybbt.log("verified: RDB data not synced to dst")
+
+    # Write new data to src — this is AOF (incremental) data
+    aof_keys = {"sync_rdb_false:aof_key1": "aof_value1", "sync_rdb_false:aof_key2": "aof_value2"}
+    for k, v in aof_keys.items():
+        src.do("set", k, v)
+
+    # Wait for AOF data to appear in dst
+    for k, v in aof_keys.items():
+        timer2 = Timer()
+        while True:
+            result = dst.do("get", k)
+            if result == v.encode():
+                break
+            if timer2.elapsed() > 10:
+                with open(f"{shake.dir}/data/shake.log") as f:
+                    pybbt.log(f.read())
+                raise TimeoutError(f"AOF key '{k}' not synced within timeout")
+            time.sleep(0.1)
+    pybbt.log("verified: AOF data synced to dst")
+
+    # Final check: dst only has AOF keys, no RDB keys
+    for k in rdb_keys:
+        pybbt.ASSERT_EQ(dst.do("get", k), None)
+    pybbt.ASSERT_EQ(dst.dbsize(), len(aof_keys))
+    pybbt.log(f"test sync_rdb_false passed. src_dbsize={src.dbsize()}, dst_dbsize={dst.dbsize()}")


### PR DESCRIPTION
## Summary

- When `sync_rdb=false`, `receiveRDB()` was still creating a `dump.rdb` file on disk. The RDB payload was received and written but never read back — wasting disk I/O / space, and the file was never cleaned up.
- Now, when `sync_rdb=false`, the RDB stream is written to `io.Discard` so the Redis replication protocol is satisfied without touching the filesystem.
- Added integration test `test_sync_rdb_false` that verifies: no `dump.rdb` on disk, RDB keys not synced to dst, AOF incremental data synced correctly.
- Refactored all test cases: `import pybbt` directly (no alias), split `@pybbt.case() def main()` into individual `@pybbt.case()` functions for better isolation.

Closes #1015

## Test plan

- [x] `test_sync_rdb_false`: validates no dump.rdb file exists, RDB data is discarded, AOF data syncs correctly
- [x] All existing integration tests pass (`python -m pybbt cases/` — 14/14 passed)
- [x] `go build ./...` compiles cleanly

🤖 Generated with [Qoder][https://qoder.com]