### PR TITLE
fix: handle optional keyword in CalcKeys to prevent panic for GEORADIUS

### DIFF
--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -40,14 +40,16 @@ func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysI
 				inx = -spec.beginSearchStartFrom
 				step = -1
 			}
-			for ; ; inx += step {
-				if inx == argc {
-					log.Panicf("not found keyword. argv=%v", argv)
-				}
+			found := false
+			for ; inx >= 0 && inx < argc; inx += step {
 				if strings.ToUpper(argv[inx]) == spec.beginSearchKeyword {
 					begin = inx + 1
+					found = true
 					break
 				}
+			}
+			if !found {
+				continue // optional keyword not present, skip this key spec
 			}
 		default:
 			log.Panicf("wrong type: %s", spec.beginSearchType)

--- a/internal/commands/keys_test.go
+++ b/internal/commands/keys_test.go
@@ -46,6 +46,36 @@ func TestCalcKeys(t *testing.T) {
 	if cmd != "COMMAND" || group != "SERVER" || !testEq(keys, []string{}) {
 		t.Errorf("CalcKeys(COMMAND) failed. cmd=%s, group=%s, keys=%v", cmd, group, keys)
 	}
+
+	// GEORADIUS with STORE
+	cmd, group, keys, _ = CalcKeys([]string{"GEORADIUS", "Sicily", "15", "37", "200", "km", "STORE", "dest"})
+	if cmd != "GEORADIUS" || group != "GEO" || !testEq(keys, []string{"Sicily", "dest"}) {
+		t.Errorf("CalcKeys(GEORADIUS with STORE) failed. cmd=%s, group=%s, keys=%v", cmd, group, keys)
+	}
+
+	// GEORADIUS with STOREDIST
+	cmd, group, keys, _ = CalcKeys([]string{"GEORADIUS", "Sicily", "15", "37", "200", "km", "STOREDIST", "dest"})
+	if cmd != "GEORADIUS" || group != "GEO" || !testEq(keys, []string{"Sicily", "dest"}) {
+		t.Errorf("CalcKeys(GEORADIUS with STOREDIST) failed. cmd=%s, group=%s, keys=%v", cmd, group, keys)
+	}
+
+	// GEORADIUS without STORE or STOREDIST
+	cmd, group, keys, _ = CalcKeys([]string{"GEORADIUS", "Sicily", "15", "37", "200", "km"})
+	if cmd != "GEORADIUS" || group != "GEO" || !testEq(keys, []string{"Sicily"}) {
+		t.Errorf("CalcKeys(GEORADIUS without STORE) failed. cmd=%s, group=%s, keys=%v", cmd, group, keys)
+	}
+
+	// GEORADIUSBYMEMBER with STORE
+	cmd, group, keys, _ = CalcKeys([]string{"GEORADIUSBYMEMBER", "Sicily", "Palermo", "200", "km", "STORE", "dest"})
+	if cmd != "GEORADIUSBYMEMBER" || group != "GEO" || !testEq(keys, []string{"Sicily", "dest"}) {
+		t.Errorf("CalcKeys(GEORADIUSBYMEMBER with STORE) failed. cmd=%s, group=%s, keys=%v", cmd, group, keys)
+	}
+
+	// GEORADIUSBYMEMBER without STORE or STOREDIST
+	cmd, group, keys, _ = CalcKeys([]string{"GEORADIUSBYMEMBER", "Sicily", "Palermo", "200", "km"})
+	if cmd != "GEORADIUSBYMEMBER" || group != "GEO" || !testEq(keys, []string{"Sicily"}) {
+		t.Errorf("CalcKeys(GEORADIUSBYMEMBER without STORE) failed. cmd=%s, group=%s, keys=%v", cmd, group, keys)
+	}
 }
 
 func TestKeyHash(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix panic when GEORADIUS/GEORADIUSBYMEMBER commands use STORE or STOREDIST options
- The keyword search loop now gracefully skips the key spec when an optional keyword is not found instead of panicking

## Problem
When executing `GEORADIUS Sicily 15 37 200 km store {Sicily}here`, RedisShake would panic with:
```
ERR not found keyword. argv=[georadius Sicily 15 37 200 km store {Sicily}here]
```

The root cause is that GEORADIUS has multiple key specs with optional keywords (STORE and STOREDIST). When one is present, the search for the other would fail and panic.

## Solution
Modified the keyword search in `CalcKeys` to use a bounded loop that checks array bounds, and skip the key spec if the optional keyword is not found.

## Test Plan
- [x] Added test cases for GEORADIUS with STORE, STOREDIST, and without either
- [x] Added test cases for GEORADIUSBYMEMBER with STORE and without STORE/STOREDIST
- [x] All existing tests pass

Fixes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)