### PR TITLE
feat: update command specs to support Redis 8.4 and Valkey 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ RedisShake is a powerful tool for Redis data transformation and migration, offer
 
 1. **Zero Downtime Migration**: Enables seamless data migration without data loss or service interruption, ensuring continuous operation during the transfer process.
 
-2. **Valkey/Redis Compatibility**: Supports Redis (2.8 to 8.x) and Valkey (8.x to 9.x) across standalone, master–slave, sentinel, and cluster deployments. See [Version Compatibility](https://tair-opensource.github.io/RedisShake/zh/others/compatibility.html) for detailed feature support.
+2. **Valkey/Redis Compatibility**: Supports Redis (2.8 to 8.4.x) and Valkey (8.x to 9.x) across standalone, master–slave, sentinel, and cluster deployments. See [Version Compatibility](https://tair-opensource.github.io/RedisShake/zh/others/compatibility.html) for detailed feature support.
 
 3. **Cloud Service Integration**: Seamlessly works with Redis-like databases from major cloud providers:
    - Alibaba Cloud: [Tair (Redis® OSS-Compatible)](https://www.alibabacloud.com/en/product/tair)

--- a/docs/src/en/others/compatibility.md
+++ b/docs/src/en/others/compatibility.md
@@ -10,8 +10,10 @@ RedisShake supports multiple Redis and Valkey versions. This document details th
 
 | Database | Supported Versions |
 |----------|-------------------|
-| Redis | 2.8 - 8.x |
+| Redis | 2.8 - 8.4.x |
 | Valkey | 8.x - 9.x |
+
+> **Note:** Command specifications are based on Redis 8.4 and Valkey 9.x (unstable), with a total of 434 commands supported.
 
 ## Redis Version Support Details
 
@@ -42,10 +44,20 @@ RedisShake supports multiple Redis and Valkey versions. This document details th
 **Newly Supported:**
 - Hash field expiration commands: HSETEX, HGETEX, HGETDEL, HTTL, HPTTL, HPERSIST, HEXPIRE, HEXPIREAT, HPEXPIRE, HPEXPIREAT, HEXPIRETIME, HPEXPIRETIME
 - Hash field expiration RDB format (RDB type 22-25)
+- XACKDEL/XDELEX commands (8.2+)
 
 **Not Supported:**
 - Vector Sets
 - Redis Stack modules (RedisJSON, RediSearch, RedisTimeSeries, RedisBloom)
+
+### Redis 8.4.x
+
+**Newly Supported Commands:**
+- Connection: CLIENT NO-TOUCH, CLIENT SETINFO
+- Cluster: CLUSTER MIGRATION, CLUSTER MYSHARDID, CLUSTER SLOT-STATS, CLUSTER SYNCSLOTS
+- String: DELEX, DIGEST, MSETEX
+- Server: SFLUSH, TRIMSLOTS
+- Generic: WAITAOF
 
 ## Valkey Version Support Details
 
@@ -60,17 +72,29 @@ RedisShake supports multiple Redis and Valkey versions. This document details th
 - Hash field expiration commands (same as Redis 8.x)
 - Hash field expiration RDB format
 
+**Valkey-specific Commands:**
+- Connection: CLIENT CAPA, CLIENT IMPORT-SOURCE
+- Cluster: CLUSTER CANCELSLOTMIGRATIONS, CLUSTER FLUSHSLOT, CLUSTER GETSLOTMIGRATIONS, CLUSTER MIGRATESLOTS
+- Server: COMMANDLOG (with subcommands: GET, HELP, LEN, RESET)
+- String: DELIFEQ
+- Scripting: SCRIPT SHOW
+- Sentinel: SENTINEL GET-PRIMARY-ADDR-BY-NAME, SENTINEL IS-PRIMARY-DOWN-BY-ADDR, SENTINEL PRIMARIES, SENTINEL PRIMARY
+
+> **Note:** Valkey uses "PRIMARY" terminology instead of "MASTER" for Sentinel commands.
+
 ## Feature Support Matrix
 
-| Feature | Redis 2.8-7.x | Redis 8.x | Valkey 8.x | Valkey 9.x |
-|---------|---------------|-----------|------------|------------|
-| Basic Data Types | ✓ | ✓ | ✓ | ✓ |
-| Stream | ✓ (5.0+) | ✓ | ✓ | ✓ |
-| Module | ✓ (4.0+) | ✓ | ✓ | ✓ |
-| Function | ✓ (7.0+) | ✓ | ✓ | ✓ |
-| Hash Field Expiration | ✗ | ✓ | ✗ | ✓ |
-| XACKDEL/XDELEX | ✗ | ✓ (8.2+) | ✗ | ✗ |
-| Vector Sets | ✗ | ✗ | ✗ | ✗ |
+| Feature | Redis 2.8-7.x | Redis 8.x | Redis 8.4.x | Valkey 8.x | Valkey 9.x |
+|---------|---------------|-----------|-------------|------------|------------|
+| Basic Data Types | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Stream | ✓ (5.0+) | ✓ | ✓ | ✓ | ✓ |
+| Module | ✓ (4.0+) | ✓ | ✓ | ✓ | ✓ |
+| Function | ✓ (7.0+) | ✓ | ✓ | ✓ | ✓ |
+| Hash Field Expiration | ✗ | ✓ | ✓ | ✗ | ✓ |
+| XACKDEL/XDELEX | ✗ | ✓ (8.2+) | ✓ | ✗ | ✗ |
+| Vector Sets | ✗ | ✗ | ✗ | ✗ | ✗ |
+| WAITAOF | ✗ | ✗ | ✓ | ✗ | ✓ |
+| COMMANDLOG | ✗ | ✗ | ✗ | ✗ | ✓ |
 
 ## Cross-Version Migration
 

--- a/docs/src/zh/others/compatibility.md
+++ b/docs/src/zh/others/compatibility.md
@@ -10,8 +10,10 @@ RedisShake 支持多种 Redis 和 Valkey 版本，本文档详细说明各版本
 
 | 数据库 | 支持版本 |
 |--------|----------|
-| Redis | 2.8 - 8.x |
+| Redis | 2.8 - 8.4.x |
 | Valkey | 8.x - 9.x |
+
+> **注意：** 命令规范基于 Redis 8.4 和 Valkey 9.x (unstable)，共计支持 434 个命令。
 
 ## Redis 版本支持详情
 
@@ -42,10 +44,20 @@ RedisShake 支持多种 Redis 和 Valkey 版本，本文档详细说明各版本
 **新增支持：**
 - Hash 字段过期命令：HSETEX、HGETEX、HGETDEL、HTTL、HPTTL、HPERSIST、HEXPIRE、HEXPIREAT、HPEXPIRE、HPEXPIREAT、HEXPIRETIME、HPEXPIRETIME
 - Hash 字段过期 RDB 格式（RDB type 22-25）
+- XACKDEL/XDELEX 命令（8.2+）
 
 **不支持：**
 - Vector Sets（向量数据类型）
 - Redis Stack 模块（RedisJSON、RediSearch、RedisTimeSeries、RedisBloom）
+
+### Redis 8.4.x
+
+**新增支持命令：**
+- 连接类：CLIENT NO-TOUCH、CLIENT SETINFO
+- 集群类：CLUSTER MIGRATION、CLUSTER MYSHARDID、CLUSTER SLOT-STATS、CLUSTER SYNCSLOTS
+- 字符串类：DELEX、DIGEST、MSETEX
+- 服务端类：SFLUSH、TRIMSLOTS
+- 通用类：WAITAOF
 
 ## Valkey 版本支持详情
 
@@ -60,17 +72,29 @@ RedisShake 支持多种 Redis 和 Valkey 版本，本文档详细说明各版本
 - Hash 字段过期命令（与 Redis 8.x 相同）
 - Hash 字段过期 RDB 格式
 
+**Valkey 独有命令：**
+- 连接类：CLIENT CAPA、CLIENT IMPORT-SOURCE
+- 集群类：CLUSTER CANCELSLOTMIGRATIONS、CLUSTER FLUSHSLOT、CLUSTER GETSLOTMIGRATIONS、CLUSTER MIGRATESLOTS
+- 服务端类：COMMANDLOG（含子命令：GET、HELP、LEN、RESET）
+- 字符串类：DELIFEQ
+- 脚本类：SCRIPT SHOW
+- 哨兵类：SENTINEL GET-PRIMARY-ADDR-BY-NAME、SENTINEL IS-PRIMARY-DOWN-BY-ADDR、SENTINEL PRIMARIES、SENTINEL PRIMARY
+
+> **注意：** Valkey 在哨兵命令中使用 "PRIMARY" 术语替代 "MASTER"。
+
 ## 特性支持矩阵
 
-| 特性 | Redis 2.8-7.x | Redis 8.x | Valkey 8.x | Valkey 9.x |
-|------|---------------|-----------|------------|------------|
-| 基础数据类型 | ✓ | ✓ | ✓ | ✓ |
-| Stream | ✓ (5.0+) | ✓ | ✓ | ✓ |
-| Module | ✓ (4.0+) | ✓ | ✓ | ✓ |
-| Function | ✓ (7.0+) | ✓ | ✓ | ✓ |
-| Hash 字段过期 | ✗ | ✓ | ✗ | ✓ |
-| XACKDEL/XDELEX | ✗ | ✓ (8.2+) | ✗ | ✗ |
-| Vector Sets | ✗ | ✗ | ✗ | ✗ |
+| 特性 | Redis 2.8-7.x | Redis 8.x | Redis 8.4.x | Valkey 8.x | Valkey 9.x |
+|------|---------------|-----------|-------------|------------|------------|
+| 基础数据类型 | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Stream | ✓ (5.0+) | ✓ | ✓ | ✓ | ✓ |
+| Module | ✓ (4.0+) | ✓ | ✓ | ✓ | ✓ |
+| Function | ✓ (7.0+) | ✓ | ✓ | ✓ | ✓ |
+| Hash 字段过期 | ✗ | ✓ | ✓ | ✗ | ✓ |
+| XACKDEL/XDELEX | ✗ | ✓ (8.2+) | ✓ | ✗ | ✗ |
+| Vector Sets | ✗ | ✗ | ✗ | ✗ | ✗ |
+| WAITAOF | ✗ | ✗ | ✓ | ✗ | ✓ |
+| COMMANDLOG | ✗ | ✗ | ✗ | ✗ | ✓ |
 
 ## 跨版本迁移
 

--- a/internal/commands/table.go
+++ b/internal/commands/table.go
@@ -1,22 +1,23 @@
 package commands
 
 var containers = map[string]bool{
-	"ACL":      true,
-	"CLIENT":   true,
-	"CLUSTER":  true,
-	"COMMAND":  true,
-	"CONFIG":   true,
-	"FUNCTION": true,
-	"LATENCY":  true,
-	"MEMORY":   true,
-	"MODULE":   true,
-	"OBJECT":   true,
-	"PUBSUB":   true,
-	"SCRIPT":   true,
-	"SENTINEL": true,
-	"SLOWLOG":  true,
-	"XGROUP":   true,
-	"XINFO":    true,
+	"ACL":        true,
+	"CLIENT":     true,
+	"CLUSTER":    true,
+	"COMMAND":    true,
+	"COMMANDLOG": true,
+	"CONFIG":     true,
+	"FUNCTION":   true,
+	"LATENCY":    true,
+	"MEMORY":     true,
+	"MODULE":     true,
+	"OBJECT":     true,
+	"PUBSUB":     true,
+	"SCRIPT":     true,
+	"SENTINEL":   true,
+	"SLOWLOG":    true,
+	"XGROUP":     true,
+	"XINFO":      true,
 }
 var redisCommands = map[string]redisCommand{
 	"ACL-CAT": {
@@ -112,6 +113,26 @@ var redisCommands = map[string]redisCommand{
 		[]keySpec{},
 	},
 	"COMMAND": {
+		"SERVER",
+		[]keySpec{},
+	},
+	"COMMANDLOG-GET": {
+		"SERVER",
+		[]keySpec{},
+	},
+	"COMMANDLOG-HELP": {
+		"SERVER",
+		[]keySpec{},
+	},
+	"COMMANDLOG-LEN": {
+		"SERVER",
+		[]keySpec{},
+	},
+	"COMMANDLOG-RESET": {
+		"SERVER",
+		[]keySpec{},
+	},
+	"COMMANDLOG": {
 		"SERVER",
 		[]keySpec{},
 	},
@@ -311,6 +332,10 @@ var redisCommands = map[string]redisCommand{
 		"SERVER",
 		[]keySpec{},
 	},
+	"SFLUSH": {
+		"SERVER",
+		[]keySpec{},
+	},
 	"SHUTDOWN": {
 		"SERVER",
 		[]keySpec{},
@@ -351,6 +376,10 @@ var redisCommands = map[string]redisCommand{
 		"SERVER",
 		[]keySpec{},
 	},
+	"TRIMSLOTS": {
+		"SERVER",
+		[]keySpec{},
+	},
 	"APPEND": {
 		"STRING",
 		[]keySpec{
@@ -388,6 +417,60 @@ var redisCommands = map[string]redisCommand{
 		},
 	},
 	"DECRBY": {
+		"STRING",
+		[]keySpec{
+			{
+				"index",
+				1,
+				"",
+				0,
+				"range",
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+			},
+		},
+	},
+	"DELEX": {
+		"STRING",
+		[]keySpec{
+			{
+				"index",
+				1,
+				"",
+				0,
+				"range",
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+			},
+		},
+	},
+	"DELIFEQ": {
+		"STRING",
+		[]keySpec{
+			{
+				"index",
+				1,
+				"",
+				0,
+				"range",
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+			},
+		},
+	},
+	"DIGEST": {
 		"STRING",
 		[]keySpec{
 			{
@@ -603,6 +686,24 @@ var redisCommands = map[string]redisCommand{
 			},
 		},
 	},
+	"MSETEX": {
+		"STRING",
+		[]keySpec{
+			{
+				"index",
+				1,
+				"",
+				0,
+				"keynum",
+				0,
+				0,
+				0,
+				0,
+				1,
+				2,
+			},
+		},
+	},
 	"MSETNX": {
 		"STRING",
 		[]keySpec{
@@ -763,6 +864,10 @@ var redisCommands = map[string]redisCommand{
 		"CLUSTER",
 		[]keySpec{},
 	},
+	"CLUSTER-CANCELSLOTMIGRATIONS": {
+		"CLUSTER",
+		[]keySpec{},
+	},
 	"CLUSTER-COUNT-FAILURE-REPORTS": {
 		"CLUSTER",
 		[]keySpec{},
@@ -783,6 +888,10 @@ var redisCommands = map[string]redisCommand{
 		"CLUSTER",
 		[]keySpec{},
 	},
+	"CLUSTER-FLUSHSLOT": {
+		"CLUSTER",
+		[]keySpec{},
+	},
 	"CLUSTER-FLUSHSLOTS": {
 		"CLUSTER",
 		[]keySpec{},
@@ -792,6 +901,10 @@ var redisCommands = map[string]redisCommand{
 		[]keySpec{},
 	},
 	"CLUSTER-GETKEYSINSLOT": {
+		"CLUSTER",
+		[]keySpec{},
+	},
+	"CLUSTER-GETSLOTMIGRATIONS": {
 		"CLUSTER",
 		[]keySpec{},
 	},
@@ -815,7 +928,19 @@ var redisCommands = map[string]redisCommand{
 		"CLUSTER",
 		[]keySpec{},
 	},
+	"CLUSTER-MIGRATESLOTS": {
+		"CLUSTER",
+		[]keySpec{},
+	},
+	"CLUSTER-MIGRATION": {
+		"CLUSTER",
+		[]keySpec{},
+	},
 	"CLUSTER-MYID": {
+		"CLUSTER",
+		[]keySpec{},
+	},
+	"CLUSTER-MYSHARDID": {
 		"CLUSTER",
 		[]keySpec{},
 	},
@@ -855,7 +980,15 @@ var redisCommands = map[string]redisCommand{
 		"CLUSTER",
 		[]keySpec{},
 	},
+	"CLUSTER-SLOT-STATS": {
+		"CLUSTER",
+		[]keySpec{},
+	},
 	"CLUSTER-SLOTS": {
+		"CLUSTER",
+		[]keySpec{},
+	},
+	"CLUSTER-SYNCSLOTS": {
 		"CLUSTER",
 		[]keySpec{},
 	},
@@ -879,6 +1012,10 @@ var redisCommands = map[string]redisCommand{
 		"CONNECTION",
 		[]keySpec{},
 	},
+	"CLIENT-CAPA": {
+		"CONNECTION",
+		[]keySpec{},
+	},
 	"CLIENT-GETNAME": {
 		"CONNECTION",
 		[]keySpec{},
@@ -892,6 +1029,10 @@ var redisCommands = map[string]redisCommand{
 		[]keySpec{},
 	},
 	"CLIENT-ID": {
+		"CONNECTION",
+		[]keySpec{},
+	},
+	"CLIENT-IMPORT-SOURCE": {
 		"CONNECTION",
 		[]keySpec{},
 	},
@@ -911,11 +1052,19 @@ var redisCommands = map[string]redisCommand{
 		"CONNECTION",
 		[]keySpec{},
 	},
+	"CLIENT-NO-TOUCH": {
+		"CONNECTION",
+		[]keySpec{},
+	},
 	"CLIENT-PAUSE": {
 		"CONNECTION",
 		[]keySpec{},
 	},
 	"CLIENT-REPLY": {
+		"CONNECTION",
+		[]keySpec{},
+	},
+	"CLIENT-SETINFO": {
 		"CONNECTION",
 		[]keySpec{},
 	},
@@ -2731,6 +2880,10 @@ var redisCommands = map[string]redisCommand{
 		"GENERIC",
 		[]keySpec{},
 	},
+	"WAITAOF": {
+		"GENERIC",
+		[]keySpec{},
+	},
 	"DISCARD": {
 		"TRANSACTIONS",
 		[]keySpec{},
@@ -2934,6 +3087,10 @@ var redisCommands = map[string]redisCommand{
 		[]keySpec{},
 	},
 	"SCRIPT-LOAD": {
+		"SCRIPTING",
+		[]keySpec{},
+	},
+	"SCRIPT-SHOW": {
 		"SCRIPTING",
 		[]keySpec{},
 	},
@@ -4317,6 +4474,10 @@ var redisCommands = map[string]redisCommand{
 		"SENTINEL",
 		[]keySpec{},
 	},
+	"SENTINEL-GET-PRIMARY-ADDR-BY-NAME": {
+		"SENTINEL",
+		[]keySpec{},
+	},
 	"SENTINEL-HELP": {
 		"SENTINEL",
 		[]keySpec{},
@@ -4326,6 +4487,10 @@ var redisCommands = map[string]redisCommand{
 		[]keySpec{},
 	},
 	"SENTINEL-IS-MASTER-DOWN-BY-ADDR": {
+		"SENTINEL",
+		[]keySpec{},
+	},
+	"SENTINEL-IS-PRIMARY-DOWN-BY-ADDR": {
 		"SENTINEL",
 		[]keySpec{},
 	},
@@ -4346,6 +4511,14 @@ var redisCommands = map[string]redisCommand{
 		[]keySpec{},
 	},
 	"SENTINEL-PENDING-SCRIPTS": {
+		"SENTINEL",
+		[]keySpec{},
+	},
+	"SENTINEL-PRIMARIES": {
+		"SENTINEL",
+		[]keySpec{},
+	},
+	"SENTINEL-PRIMARY": {
 		"SENTINEL",
 		[]keySpec{},
 	},

--- a/scripts/commands/client-capa.json
+++ b/scripts/commands/client-capa.json
@@ -1,0 +1,31 @@
+{
+    "CAPA": {
+        "summary": "A client claims its capability.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "8.0.0",
+        "arity": -3,
+        "container": "CLIENT",
+        "function": "clientCapaCommand",
+        "command_flags": [
+            "ALLOW_BUSY",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "CONNECTION",
+            "SLOW"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "multiple": "true",
+                "name": "capability",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/scripts/commands/client-import-source.json
+++ b/scripts/commands/client-import-source.json
@@ -1,0 +1,41 @@
+{
+    "IMPORT-SOURCE": {
+        "summary": "Mark this client as an import source when server is in import mode.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "8.1.0",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientImportSourceCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "CONNECTION",
+            "SLOW"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "enabled",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "on",
+                        "type": "pure-token",
+                        "token": "ON"
+                    },
+                    {
+                        "name": "off",
+                        "type": "pure-token",
+                        "token": "OFF"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/client-no-touch.json
+++ b/scripts/commands/client-no-touch.json
@@ -1,0 +1,40 @@
+{
+    "NO-TOUCH": {
+        "summary": "Controls whether commands sent by the client affect the LRU/LFU of accessed keys.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "7.2.0",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "enabled",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "on",
+                        "type": "pure-token",
+                        "token": "ON"
+                    },
+                    {
+                        "name": "off",
+                        "type": "pure-token",
+                        "token": "OFF"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/client-setinfo.json
+++ b/scripts/commands/client-setinfo.json
@@ -1,0 +1,45 @@
+{
+    "SETINFO": {
+        "summary": "Sets information specific to the client or connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "7.2.0",
+        "arity": 4,
+        "container": "CLIENT",
+        "function": "clientSetinfoCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],        
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "attr",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "token": "lib-name",
+                        "name": "libname",
+                        "type": "string"
+                    },
+                    {
+                        "token": "lib-ver",
+                        "name": "libver",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/cluster-cancelslotmigrations.json
+++ b/scripts/commands/cluster-cancelslotmigrations.json
@@ -1,0 +1,25 @@
+{
+    "CANCELSLOTMIGRATIONS": {
+        "summary": "Cancel all current ongoing slot migration operations.",
+        "complexity": "O(N), where N is the number of slot migration operations being cancelled.",
+        "group": "cluster",
+        "since": "9.0.0",
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "arity": 2,
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE",
+            "ALL_DBS"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/cluster-flushslot.json
+++ b/scripts/commands/cluster-flushslot.json
@@ -1,0 +1,49 @@
+{
+    "FLUSHSLOT": {
+        "summary": "Remove all keys from the target slot.",
+        "complexity": "O(N) where N is the number of keys in the target slot",
+        "group": "cluster",
+        "since": "9.0.0",
+        "arity": -3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "WRITE",
+            "NO_ASYNC_LOADING",
+            "ADMIN"
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "KEYSPACE",
+            "SLOW",
+            "WRITE"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "slot",
+                "type": "integer"
+            },
+            {
+                "name": "flush-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "async",
+                        "type": "pure-token",
+                        "token": "ASYNC"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/cluster-getslotmigrations.json
+++ b/scripts/commands/cluster-getslotmigrations.json
@@ -1,0 +1,85 @@
+{
+    "GETSLOTMIGRATIONS": {
+        "summary": "Get the status of ongoing and recently finished slot import and export operations.",
+        "complexity": "O(N), where N is the number of active slot import and export jobs.",
+        "group": "cluster",
+        "since": "9.0.0",
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "arity": 2,
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "reply_schema": {
+            "description": "A nested list of maps, one for each migration, with keys and values representing migration fields.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "link_name": {
+                        "type": "string",
+                        "description": "A 40-byte randomly generated hex string representing the migration.",
+                        "pattern": "^[0-9a-fA-F]{40}$"
+                    },
+                    "operation": {
+                        "oneOf": [
+                            {
+                                "const": "IMPORT"
+                            },
+                            {
+                                "const": "EXPORT"
+                            }
+                        ]
+                    },
+                    "slot_ranges": {
+                        "description": "Slot ranges in the format <start>-<end> inclusive, each range separated by a space.",
+                        "type": "string",
+                        "pattern": "^([0-9]+-[0-9]+)( [0-9]+-[0-9]+)*$"
+                    },
+                    "target_node": {
+                        "description": "The target node name in the migration job.",
+                        "type": "string",
+                        "pattern": "^[0-9a-fA-F]{40}$"
+                    },
+                    "source_node": {
+                        "description": "The source node name in the migration job.",
+                        "type": "string",
+                        "pattern": "^[0-9a-fA-F]{40}$"
+                    },
+                    "create_time": {
+                        "description": "Creation time, in seconds since the unix epoch.",
+                        "type": "integer"
+                    },
+                    "last_update_time": {
+                        "description": "Last update time, in seconds since the unix epoch.",
+                        "type": "integer"
+                    },
+                    "last_ack_time": {
+                        "description": "Last received ack time, in seconds since the unix epoch.",
+                        "type": "integer"
+                    },
+                    "state": {
+                        "description": "Human readable string representing the migration job state.",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Human readable status message with more details.",
+                        "type": "string"
+                    },
+                    "cow_size": {
+                        "description": "Copy on write bytes during slot migration fork.",
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/cluster-migrateslots.json
+++ b/scripts/commands/cluster-migrateslots.json
@@ -1,0 +1,67 @@
+{
+    "MIGRATESLOTS": {
+        "summary": "Migrate the given slots from this node to the specified nodes.",
+        "complexity": "O(N) where N is the total number of the slots between all start slot and end slot arguments.",
+        "group": "cluster",
+        "since": "9.0.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE",
+            "ALL_DBS"
+        ],
+        "arguments": [
+            {
+                "name": "migration-group",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "slotsrange-token",
+                        "type": "pure-token",
+                        "token": "SLOTSRANGE",
+                        "description": "One or more ranges of slots to be migrated."
+                    },
+                    {
+                        "name": "range",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer"
+                            }
+                        ],
+                        "description": "Start and end slot for single range"
+                    },
+                    {
+                        "name": "node-token",
+                        "type": "pure-token",
+                        "token": "NODE"
+                    },
+                    {
+                        "name": "node-id",
+                        "type": "string",
+                        "pattern": "^[0-9a-fA-F]{40}$",
+                        "description": "40 character node name of the node to migrate to"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/cluster-migration.json
+++ b/scripts/commands/cluster-migration.json
@@ -1,0 +1,141 @@
+{
+    "MIGRATION": {
+        "summary": "Start, monitor and cancel slot migration.",
+        "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
+        "group": "cluster",
+        "since": "8.4.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "subcommand",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "import",
+                        "token": "IMPORT",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "cancel",
+                        "token": "CANCEL",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "token": "ID",
+                                "name": "task-id",
+                                "type": "string"
+                            },
+                            {
+                                "name": "all",
+                                "token": "ALL",
+                                "type": "pure-token"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "status",
+                        "token": "STATUS",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "token": "ID",
+                                "name": "task-id",
+                                "type": "string",
+                                "optional": true
+                            },
+                            {
+                                "name": "all",
+                                "token": "ALL",
+                                "type": "pure-token",
+                                "optional": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Reply to CLUSTER MIGRATION IMPORT, returns the task ID.",
+                    "type": "string"
+                },
+                {
+                    "description": "Reply to CLUSTER MIGRATION CANCEL, number of cancelled migration operations.",
+                    "type": "integer"
+                },
+                {
+                    "description": "Reply to CLUSTER MIGRATION STATUS, array of migration operation details.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "slots": {
+                                "type": "string"
+                            },
+                            "source": {
+                                "type": "string"
+                            },
+                            "dest": {
+                                "type": "string"
+                            },
+                            "operation": {
+                                "oneOf": [
+                                    {
+                                        "const": "import"
+                                    },
+                                    {
+                                        "const": "migrate"
+                                    }
+                                ]
+                            },
+                            "state": {
+                                "type": "string"
+                            },
+                            "last_error": {
+                                "type": "string"
+                            },
+                            "retries": {
+                                "type": "integer"
+                            },
+                            "create_time": {
+                                "type": "integer"
+                            },
+                            "start_time": {
+                                "type": "integer"
+                            },
+                            "end_time": {
+                                "type": "integer"
+                            },
+                            "write_pause_ms": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/scripts/commands/cluster-myshardid.json
+++ b/scripts/commands/cluster-myshardid.json
@@ -1,0 +1,22 @@
+{
+    "MYSHARDID": {
+        "summary": "Returns the shard ID of a node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "7.2.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "history": [],
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "the node's shard id",
+            "type": "string"
+        }
+    }
+}

--- a/scripts/commands/cluster-slot-stats.json
+++ b/scripts/commands/cluster-slot-stats.json
@@ -1,0 +1,114 @@
+{
+    "SLOT-STATS": {
+        "summary": "Return an array of slot usage statistics for slots assigned to the current node.",
+        "complexity": "O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.",
+        "group": "cluster",
+        "since": "8.2.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterSlotStatsCommand",
+        "command_flags": [
+            "STALE",
+            "LOADING"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Array of nested arrays, where the inner array element represents a slot and its respective usage statistics.",
+            "items": {
+                "type": "array",
+                "description": "Array of size 2, where 0th index represents (int) slot and 1st index represents (map) usage statistics.",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                    {
+                        "description": "Slot Number.",
+                        "type": "integer"
+                    },
+                    {
+                        "type": "object",
+                        "description": "Map of slot usage statistics.",
+                        "additionalProperties": false,
+                        "properties": {
+                            "key-count": {
+                                "type": "integer"
+                            },
+                            "memory-bytes": {
+                                "type": "integer"
+                            },
+                            "cpu-usec": {
+                                "type": "integer"
+                            },
+                            "network-bytes-in": {
+                                "type": "integer"
+                            },
+                            "network-bytes-out": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "filter",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "token": "SLOTSRANGE",
+                        "name": "slotsrange",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "token": "ORDERBY",
+                        "name": "orderby",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "metric",
+                                "type": "string"
+                            },
+                            {
+                                "token": "LIMIT",
+                                "name": "limit",
+                                "type": "integer",
+                                "optional": true
+                            },
+                            {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                    {
+                                        "name": "asc",
+                                        "type": "pure-token",
+                                        "token": "ASC"
+                                    },
+                                    {
+                                        "name": "desc",
+                                        "type": "pure-token",
+                                        "token": "DESC"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/cluster-syncslots.json
+++ b/scripts/commands/cluster-syncslots.json
@@ -1,0 +1,117 @@
+{
+    "SYNCSLOTS": {
+        "summary": "Internal command for atomic slot migration protocol between cluster nodes.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "8.4.0",
+        "arity": -3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "arguments": [
+            {
+                "name": "subcommand",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "sync",
+                        "token": "SYNC",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "task-id",
+                                "type": "string"
+                            },
+                            {
+                                "name": "slot-range",
+                                "type": "block",
+                                "multiple": true,
+                                "arguments": [
+                                    {
+                                        "name": "start-slot",
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "name": "end-slot",
+                                        "type": "integer"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "token": "RDBCHANNEL",
+                        "name": "task-id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "snapshot-eof",
+                        "token": "SNAPSHOT-EOF",
+                        "type": "pure-token"
+                    },
+                    {
+                        "name": "stream-eof",
+                        "token": "STREAM-EOF",
+                        "type": "pure-token"
+                    },
+                    {
+                        "name": "ack",
+                        "token": "ACK",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "state",
+                                "type": "string"
+                            },
+                            {
+                                "name": "offset",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "token": "FAIL",
+                        "name": "error",
+                        "type": "string"
+                    },
+                    {
+                        "name": "conf",
+                        "token": "CONF",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "option",
+                                "type": "string",
+                                "multiple": true
+                            },
+                            {
+                                "name": "value",
+                                "type": "string",
+                                "multiple": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Reply to CLUSTER SYNCSLOTS SYNC, returns special RDB channel sync response.",
+                    "const": "RDBCHANNELSYNCSLOTS"
+                },
+                {
+                    "description": "Reply to CLUSTER SYNCSLOTS CONF and other subcommands.",
+                    "const": "OK"
+                }
+            ]
+        }
+    }
+}

--- a/scripts/commands/commandlog-get.json
+++ b/scripts/commands/commandlog-get.json
@@ -1,0 +1,93 @@
+{
+    "GET": {
+        "summary": "Returns the specified command log's entries.",
+        "complexity": "O(N) where N is the number of entries returned",
+        "group": "server",
+        "since": "8.1.0",
+        "arity": 4,
+        "container": "COMMANDLOG",
+        "function": "commandlogCommand",
+        "command_flags": [
+            "ADMIN",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Entries from the command log in chronological order.",
+            "uniqueItems": true,
+            "items": {
+                "type": "array",
+                "minItems": 6,
+                "maxItems": 6,
+                "items": [
+                    {
+                        "type": "integer",
+                        "description": "Command log entry ID."
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The unix timestamp at which the logged command was processed.",
+                        "minimum": 0
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Determined by the type parameter.",
+                        "minimum": 0
+                    },
+                    {
+                        "type": "array",
+                        "description": "The arguments of the command.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client IP address and port."
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client name if set via the CLIENT SETNAME command."
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "count",
+                "type": "integer"
+            },
+            {
+                "name": "type",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "slow",
+                        "type": "pure-token",
+                        "token": "slow"
+                    },
+                    {
+                        "name": "large-request",
+                        "type": "pure-token",
+                        "token": "large-request"
+                    },
+                    {
+                        "name": "large-reply",
+                        "type": "pure-token",
+                        "token": "large-reply"
+                    }
+                ]
+            }
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/commandlog-help.json
+++ b/scripts/commands/commandlog-help.json
@@ -1,0 +1,25 @@
+{
+    "HELP": {
+        "summary": "Show helpful text about the different subcommands",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "8.1.0",
+        "arity": 2,
+        "container": "COMMANDLOG",
+        "function": "commandlogCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "acl_categories": [
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/commandlog-len.json
+++ b/scripts/commands/commandlog-len.json
@@ -1,0 +1,54 @@
+{
+    "LEN": {
+        "summary": "Returns the number of entries in the specified type of command log.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "8.1.0",
+        "arity": 3,
+        "container": "COMMANDLOG",
+        "function": "commandlogCommand",
+        "command_flags": [
+            "ADMIN",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:AGG_SUM",
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of entries in the command log.",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "type",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "slow",
+                        "type": "pure-token",
+                        "token": "slow"
+                    },
+                    {
+                        "name": "large-request",
+                        "type": "pure-token",
+                        "token": "large-request"
+                    },
+                    {
+                        "name": "large-reply",
+                        "type": "pure-token",
+                        "token": "large-reply"
+                    }
+                ]
+            }
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/commandlog-reset.json
+++ b/scripts/commands/commandlog-reset.json
@@ -1,0 +1,51 @@
+{
+    "RESET": {
+        "summary": "Clears all entries from the specified type of command log.",
+        "complexity": "O(N) where N is the number of entries in the commandlog",
+        "group": "server",
+        "since": "8.1.0",
+        "arity": 3,
+        "container": "COMMANDLOG",
+        "function": "commandlogCommand",
+        "command_flags": [
+            "ADMIN",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "type",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "slow",
+                        "type": "pure-token",
+                        "token": "slow"
+                    },
+                    {
+                        "name": "large-request",
+                        "type": "pure-token",
+                        "token": "large-request"
+                    },
+                    {
+                        "name": "large-reply",
+                        "type": "pure-token",
+                        "token": "large-reply"
+                    }
+                ]
+            }
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/commandlog.json
+++ b/scripts/commands/commandlog.json
@@ -1,0 +1,12 @@
+{
+    "COMMANDLOG": {
+        "summary": "A container for command log commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "8.1.0",
+        "arity": -2,
+        "acl_categories": [
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/delex.json
+++ b/scripts/commands/delex.json
@@ -1,0 +1,89 @@
+{
+    "DELEX": {
+        "summary": "Conditionally removes the specified key based on value or digest comparison.",
+        "complexity": "O(1) for IFEQ/IFNE, O(N) for IFDEQ/IFDNE where N is the length of the string value.",
+        "group": "string",
+        "since": "8.4.0",
+        "arity": -2,
+        "function": "delexCommand",
+        "get_keys_function": "delexGetKeys",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE",
+                    "VARIABLE_FLAGS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The key exists but holds a non-string value",
+                    "const": "WRONGTYPE"
+                },
+                {
+                    "description": "The key does not exist or the specified condition was not met.",
+                    "const": 0
+                },
+                {
+                    "description": "The key was deleted.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "ifeq-value",
+                        "type": "string",
+                        "token": "IFEQ"
+                    },
+                    {
+                        "name": "ifne-value",
+                        "type": "string",
+                        "token": "IFNE"
+                    },
+                    {
+                        "name": "ifdeq-digest",
+                        "type": "integer",
+                        "token": "IFDEQ"
+                    },
+                    {
+                        "name": "ifdne-digest",
+                        "type": "integer",
+                        "token": "IFDNE"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/delifeq.json
+++ b/scripts/commands/delifeq.json
@@ -1,0 +1,62 @@
+{
+    "DELIFEQ": {
+        "summary": "Delete key if value matches string.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "9.0.0",
+        "arity": 3,
+        "function": "delifeqCommand",
+        "command_flags": [
+            "FAST",
+            "WRITE"
+        ],
+        "acl_categories": [
+            "FAST",
+            "STRING",
+            "WRITE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RM",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The key was not deleted.",
+                    "const": 0
+                },
+                {
+                    "description": "The key was deleted.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/scripts/commands/digest.json
+++ b/scripts/commands/digest.json
@@ -1,0 +1,56 @@
+{
+    "DIGEST": {
+        "summary": "Returns the XXH3 hash of a string value.",
+        "complexity": "O(N) where N is the length of the string value.",
+        "group": "string",
+        "since": "8.4.0",
+        "arity": 2,
+        "function": "digestCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The XXH3 64-bit hash of the string value as a signed integer.",
+                    "type": "string"
+                },
+                {
+                    "description": "Key does not exist",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/scripts/commands/msetex.json
+++ b/scripts/commands/msetex.json
@@ -1,0 +1,124 @@
+{
+    "MSETEX": {
+        "summary": "Atomically sets multiple string keys with a shared expiration in a single operation. Supports flexible argument parsing where condition and expiration flags can appear in any order.",
+        "complexity": "O(N) where N is the number of keys to set.",
+        "group": "string",
+        "since": "8.4.0",
+        "arity": -4,
+        "function": "msetexCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 2
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "No key was set (at least one key failed).",
+                    "const": 0
+                },
+                {
+                    "description": "All the keys were set.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    }
+                ]
+            },
+            {
+                "name": "expiration",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "seconds",
+                        "type": "integer",
+                        "token": "EX"
+                    },
+                    {
+                        "name": "milliseconds",
+                        "type": "integer",
+                        "token": "PX"
+                    },
+                    {
+                        "name": "unix-time-seconds",
+                        "type": "unix-time",
+                        "token": "EXAT"
+                    },
+                    {
+                        "name": "unix-time-milliseconds",
+                        "type": "unix-time",
+                        "token": "PXAT"
+                    },
+                    {
+                        "name": "keepttl",
+                        "type": "pure-token",
+                        "token": "KEEPTTL"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/script-show.json
+++ b/scripts/commands/script-show.json
@@ -1,0 +1,29 @@
+{
+    "SHOW": {
+        "summary": "Show server-side Lua script in the script cache.",
+        "complexity": "O(1).",
+        "group": "scripting",
+        "since": "8.0.0",
+        "arity": 3,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING",
+            "SLOW"
+        ],
+        "arguments": [
+            {
+                "name": "sha1",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "Lua script if sha1 hash exists in script cache.",
+            "type": "string"
+        }
+    }
+}

--- a/scripts/commands/sentinel-get-primary-addr-by-name.json
+++ b/scripts/commands/sentinel-get-primary-addr-by-name.json
@@ -1,0 +1,43 @@
+{
+    "GET-PRIMARY-ADDR-BY-NAME": {
+        "summary": "Returns the port and address of a primary instance.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "8.0.0",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "type": "string",
+                    "description": "IP addr or hostname."
+                },
+                {
+                    "type": "string",
+                    "description": "Port.",
+                    "pattern": "[0-9]+"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "primary-name",
+                "type": "string"
+            }
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/sentinel-is-primary-down-by-addr.json
+++ b/scripts/commands/sentinel-is-primary-down-by-addr.json
@@ -1,0 +1,66 @@
+{
+    "IS-PRIMARY-DOWN-BY-ADDR": {
+        "summary": "Determines whether a primary instance is down.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "8.0.0",
+        "arity": 6,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "items": [
+                {
+                    "oneOf": [
+                        {
+                            "const": 0,
+                            "description": "Primary is up."
+                        },
+                        {
+                            "const": 1,
+                            "description": "Primary is down."
+                        }
+                    ]
+                },
+                {
+                    "type": "string",
+                    "description": "Sentinel address."
+                },
+                {
+                    "type": "integer",
+                    "description": "Port."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "ip",
+                "type": "string"
+            },
+            {
+                "name": "port",
+                "type": "integer"
+            },
+            {
+                "name": "current-epoch",
+                "type": "integer"
+            },
+            {
+                "name": "runid",
+                "type": "string"
+            }
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/sentinel-primaries.json
+++ b/scripts/commands/sentinel-primaries.json
@@ -1,0 +1,31 @@
+{
+    "PRIMARIES": {
+        "summary": "Returns a list of monitored primaries.",
+        "complexity": "O(N) where N is the number of primaries",
+        "group": "sentinel",
+        "since": "8.0.0",
+        "arity": 2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of monitored primaries, and their states.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            }
+        },
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/sentinel-primary.json
+++ b/scripts/commands/sentinel-primary.json
@@ -1,0 +1,34 @@
+{
+    "PRIMARY": {
+        "summary": "Returns the state of a primary instance.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "8.0.0",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "description": "The state and info of the specified primary.",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "primary-name",
+                "type": "string"
+            }
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ]
+    }
+}

--- a/scripts/commands/sflush.json
+++ b/scripts/commands/sflush.json
@@ -1,0 +1,75 @@
+{
+    "SFLUSH": {
+        "summary": "Remove all keys from selected range of slots.",
+        "complexity": "O(N)+O(k) where N is the number of keys and k is the number of slots.",
+        "group": "server",
+        "since": "8.0.0",
+        "arity": -3,
+        "function": "sflushCommand",
+        "command_flags": [
+            "WRITE",
+            "EXPERIMENTAL"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "command_tips": [
+        ],
+        "reply_schema": {
+            "description": "List of slot ranges",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                    {
+                        "description": "start slot number",
+                        "type": "integer"
+                    },
+                    {
+                        "description": "end slot number",
+                        "type": "integer"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "slot-start",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "slot-last",
+                        "type": "integer"
+                    }
+                ]
+            },
+            {
+                "name": "flush-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "async",
+                        "type": "pure-token",
+                        "token": "ASYNC"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/trimslots.json
+++ b/scripts/commands/trimslots.json
@@ -1,0 +1,48 @@
+{
+    "TRIMSLOTS": {
+        "summary": "Trim the keys that belong to specified slots.",
+        "complexity": "O(N) where N is the total number of keys in all databases",
+        "group": "server",
+        "since": "8.4.0",
+        "arity": -5,
+        "function": "trimslotsCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "ranges",
+                "token": "RANGES",
+                "type": "block",
+                "arguments": [
+                    {
+                        "name": "numranges",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "slots",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "startslot",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "endslot",
+                                "type": "integer"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/scripts/commands/waitaof.json
+++ b/scripts/commands/waitaof.json
@@ -1,0 +1,52 @@
+{
+    "WAITAOF": {
+        "summary": "Blocks until all of the preceding write commands sent by the connection are written to the append-only file of the master and/or replicas.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "7.2.0",
+        "arity": 4,
+        "function": "waitaofCommand",
+        "command_flags": [
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:AGG_MIN"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Number of local and remote AOF files in sync.",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "description": "Number of local AOF files.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "description": "Number of replica AOF files.",
+                    "type": "number",
+                    "minimum": 0
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numlocal",
+                "type": "integer"
+            },
+            {
+                "name": "numreplicas",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/scripts/table.json
+++ b/scripts/table.json
@@ -25,6 +25,11 @@
             "COMMAND-INFO": [],
             "COMMAND-LIST": [],
             "COMMAND": [],
+            "COMMANDLOG-GET": [],
+            "COMMANDLOG-HELP": [],
+            "COMMANDLOG-LEN": [],
+            "COMMANDLOG-RESET": [],
+            "COMMANDLOG": [],
             "CONFIG-GET": [],
             "CONFIG-HELP": [],
             "CONFIG-RESETSTAT": [],
@@ -97,6 +102,7 @@
             ],
             "ROLE": [],
             "SAVE": [],
+            "SFLUSH": [],
             "SHUTDOWN": [],
             "SLAVEOF": [],
             "SLOWLOG-GET": [],
@@ -106,7 +112,8 @@
             "SLOWLOG": [],
             "SWAPDB": [],
             "SYNC": [],
-            "TIME": []
+            "TIME": [],
+            "TRIMSLOTS": []
         },
         "string": {
             "APPEND": [
@@ -142,6 +149,54 @@
                 }
             ],
             "DECRBY": [
+                {
+                    "begin_search": {
+                        "index": {
+                            "pos": 1
+                        }
+                    },
+                    "find_keys": {
+                        "range": {
+                            "lastkey": 0,
+                            "step": 1,
+                            "limit": 0
+                        }
+                    }
+                }
+            ],
+            "DELEX": [
+                {
+                    "begin_search": {
+                        "index": {
+                            "pos": 1
+                        }
+                    },
+                    "find_keys": {
+                        "range": {
+                            "lastkey": 0,
+                            "step": 1,
+                            "limit": 0
+                        }
+                    }
+                }
+            ],
+            "DELIFEQ": [
+                {
+                    "begin_search": {
+                        "index": {
+                            "pos": 1
+                        }
+                    },
+                    "find_keys": {
+                        "range": {
+                            "lastkey": 0,
+                            "step": 1,
+                            "limit": 0
+                        }
+                    }
+                }
+            ],
+            "DIGEST": [
                 {
                     "begin_search": {
                         "index": {
@@ -333,6 +388,22 @@
                     }
                 }
             ],
+            "MSETEX": [
+                {
+                    "begin_search": {
+                        "index": {
+                            "pos": 1
+                        }
+                    },
+                    "find_keys": {
+                        "keynum": {
+                            "keynumidx": 0,
+                            "firstkey": 1,
+                            "step": 2
+                        }
+                    }
+                }
+            ],
             "MSETNX": [
                 {
                     "begin_search": {
@@ -467,20 +538,26 @@
             "CLUSTER-ADDSLOTS": [],
             "CLUSTER-ADDSLOTSRANGE": [],
             "CLUSTER-BUMPEPOCH": [],
+            "CLUSTER-CANCELSLOTMIGRATIONS": [],
             "CLUSTER-COUNT-FAILURE-REPORTS": [],
             "CLUSTER-COUNTKEYSINSLOT": [],
             "CLUSTER-DELSLOTS": [],
             "CLUSTER-DELSLOTSRANGE": [],
             "CLUSTER-FAILOVER": [],
+            "CLUSTER-FLUSHSLOT": [],
             "CLUSTER-FLUSHSLOTS": [],
             "CLUSTER-FORGET": [],
             "CLUSTER-GETKEYSINSLOT": [],
+            "CLUSTER-GETSLOTMIGRATIONS": [],
             "CLUSTER-HELP": [],
             "CLUSTER-INFO": [],
             "CLUSTER-KEYSLOT": [],
             "CLUSTER-LINKS": [],
             "CLUSTER-MEET": [],
+            "CLUSTER-MIGRATESLOTS": [],
+            "CLUSTER-MIGRATION": [],
             "CLUSTER-MYID": [],
+            "CLUSTER-MYSHARDID": [],
             "CLUSTER-NODES": [],
             "CLUSTER-REPLICAS": [],
             "CLUSTER-REPLICATE": [],
@@ -490,7 +567,9 @@
             "CLUSTER-SETSLOT": [],
             "CLUSTER-SHARDS": [],
             "CLUSTER-SLAVES": [],
+            "CLUSTER-SLOT-STATS": [],
             "CLUSTER-SLOTS": [],
+            "CLUSTER-SYNCSLOTS": [],
             "CLUSTER": [],
             "READONLY": [],
             "READWRITE": []
@@ -498,16 +577,20 @@
         "connection": {
             "AUTH": [],
             "CLIENT-CACHING": [],
+            "CLIENT-CAPA": [],
             "CLIENT-GETNAME": [],
             "CLIENT-GETREDIR": [],
             "CLIENT-HELP": [],
             "CLIENT-ID": [],
+            "CLIENT-IMPORT-SOURCE": [],
             "CLIENT-INFO": [],
             "CLIENT-KILL": [],
             "CLIENT-LIST": [],
             "CLIENT-NO-EVICT": [],
+            "CLIENT-NO-TOUCH": [],
             "CLIENT-PAUSE": [],
             "CLIENT-REPLY": [],
+            "CLIENT-SETINFO": [],
             "CLIENT-SETNAME": [],
             "CLIENT-TRACKING": [],
             "CLIENT-TRACKINGINFO": [],
@@ -2109,7 +2192,8 @@
                     }
                 }
             ],
-            "WAIT": []
+            "WAIT": [],
+            "WAITAOF": []
         },
         "transactions": {
             "DISCARD": [],
@@ -2246,6 +2330,7 @@
             "SCRIPT-HELP": [],
             "SCRIPT-KILL": [],
             "SCRIPT-LOAD": [],
+            "SCRIPT-SHOW": [],
             "SCRIPT": []
         },
         "TairHash": {
@@ -3468,14 +3553,18 @@
             "SENTINEL-FAILOVER": [],
             "SENTINEL-FLUSHCONFIG": [],
             "SENTINEL-GET-MASTER-ADDR-BY-NAME": [],
+            "SENTINEL-GET-PRIMARY-ADDR-BY-NAME": [],
             "SENTINEL-HELP": [],
             "SENTINEL-INFO-CACHE": [],
             "SENTINEL-IS-MASTER-DOWN-BY-ADDR": [],
+            "SENTINEL-IS-PRIMARY-DOWN-BY-ADDR": [],
             "SENTINEL-MASTER": [],
             "SENTINEL-MASTERS": [],
             "SENTINEL-MONITOR": [],
             "SENTINEL-MYID": [],
             "SENTINEL-PENDING-SCRIPTS": [],
+            "SENTINEL-PRIMARIES": [],
+            "SENTINEL-PRIMARY": [],
             "SENTINEL-REMOVE": [],
             "SENTINEL-REPLICAS": [],
             "SENTINEL-RESET": [],
@@ -3867,6 +3956,7 @@
         "CLIENT",
         "CLUSTER",
         "COMMAND",
+        "COMMANDLOG",
         "CONFIG",
         "FUNCTION",
         "LATENCY",


### PR DESCRIPTION
## Summary

- Add 12 new commands from Redis 8.4
- Add 17 Valkey-specific commands
- Update documentation with version compatibility details
- Total commands: 434 (up from 405)

## Test plan

- Verify build passes
- Verify existing tests pass with new command definitions