### PR TITLE
fix: correct AOF size calculation by traversing incrAOFList instead o…

### DIFF
--- a/internal/reader/parsing_aof.go
+++ b/internal/reader/parsing_aof.go
@@ -523,7 +523,7 @@ func (aofInfo *INFO) GetBaseAndIncrAppendOnlyFilesSize(am *AOFManifest, status *
 		}
 	}
 
-	for ln := am.HistoryList.Front(); ln != nil; ln = ln.Next() {
+	for ln := am.incrAOFList.Front(); ln != nil; ln = ln.Next() {
 		ai := ln.Value.(*AOFInfo)
 		if ai.AOFFileType != AOFManifestTypeIncr {
 			log.Panicf("File type must be Incr")


### PR DESCRIPTION
The GetBaseAndIncrAppendOnlyFileSize function was incorrectly iterating over 
am.HistoryList to calculate the total size of incremental AOF files. 

This commit updates the logic to traverse am.incrAOFList, ensuring only 
active incremental files are accounted for.

Fixes https://github.com/tair-opensource/RedisShake/issues/1030