### PR TITLE
fix: ensure synchronous data forwarding for RDB base files in AOF loading

### DIFF
--- a/internal/reader/parsing_aof.go
+++ b/internal/reader/parsing_aof.go
@@ -727,7 +727,12 @@ func (aofInfo *INFO) ParsingSingleAppendOnlyFile(ctx context.Context, FileName s
 		log.Infof("Reading RDB Base File on AOF loading...")
 		rdbOpt := RdbReaderOptions{Filepath: AOFFilepath}
 		ldRDB := NewRDBReader(&rdbOpt)
-		ldRDB.StartRead(ctx)
+		rdbChrs := ldRDB.StartRead(ctx)
+		for _, chr := range rdbChrs {
+			for e := range chr {
+				aofInfo.ch <- e
+			}
+		}
 		return AOFOk
 	}
 	// load single aof file


### PR DESCRIPTION
The previous implementation of ParsingSingleAppendOnlyFile for RDB base files 
failed to bind the RDB reader's output channel to the global aofInfo channel. 
Additionally, it returned AOFOk prematurely before the RDB data was fully 
processed, leading to potential data disorder between Base and Incr files.

Changes:
- Implemented a synchronous loop to forward all entries from ldRDB to aofInfo.ch.
- Guaranteed that the function only returns after the RDB file is completely read.
- Maintained the strict restoration order: Base first, then Incremental.