### PR TITLE
docs: add Go prerequisite to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ docker run --network host \
 ```
 
 3. Build it yourself:
+
+> **Prerequisite:** Go must be installed and available in your system before running the build script.
+   
 ```shell
 git clone https://github.com/tair-opensource/RedisShake
 cd RedisShake


### PR DESCRIPTION
This PR adds a note to the build instructions indicating that Go must be installed before running the `build.sh` script.

This helps prevent confusion for users attempting to build the project locally without having Go installed.