### PR TITLE
Add scan reader queue backpressure

### DIFF
--- a/docs/src/en/reader/scan_reader.md
+++ b/docs/src/en/reader/scan_reader.md
@@ -48,6 +48,7 @@ dbs = []                   # set you want to scan dbs such as [1,5,7], if you do
 scan = true                # set to false if you don't want to scan keys
 ksn = false                # set to true to enabled Redis keyspace notifications (KSN) subscription
 count = 1                  # number of keys to scan per iteration
+scan_max_queue_len = 0     # pause SCAN when the internal dump queue reaches this length, 0 disables backpressure
 ```
 
 * `cluster`: Whether the source is a cluster
@@ -61,3 +62,4 @@ count = 1                  # number of keys to scan per iteration
 * `scan`: Whether to enable the SCAN stage. When set to false, RedisShake will skip the full synchronization stage
 * `ksn`: After enabling the `ksn` parameter, RedisShake will subscribe to Key changes at the source to achieve incremental synchronization
 * `count`: The number of keys fetched from the source each time during full synchronization. The default is 1. Changing to a larger value can significantly improve synchronization efficiency, but will also increase pressure on the source.
+* `scan_max_queue_len`: Only applies to the SCAN stage. When the internal pending DUMP queue reaches this threshold, RedisShake pauses further SCAN calls; scanning resumes automatically once the queue length falls below the threshold. `ksn` subscriptions are not affected. Set to `0` to disable this backpressure.

--- a/docs/src/zh/reader/scan_reader.md
+++ b/docs/src/zh/reader/scan_reader.md
@@ -51,6 +51,7 @@ dbs = []                   # set you want to scan dbs such as [1,5,7], if you do
 scan = true                # set to false if you don't want to scan keys
 ksn = false                # set to true to enabled Redis keyspace notifications (KSN) subscription
 count = 1                  # number of keys to scan per iteration
+scan_max_queue_len = 0     # pause SCAN when the internal dump queue reaches this length, 0 disables backpressure
 ```
 
 * `cluster`：源端是否为集群
@@ -64,3 +65,4 @@ count = 1                  # number of keys to scan per iteration
 * `scan`：是否开启 SCAN 阶段，设置为 false 时，RedisShake 会跳过全量同步阶段
 * `ksn`：开启 `ksn` 参数后，RedisShake 会订阅源端的 Key 变化，实现增量同步
 * `count`：全量同步时每次从源端拉取的 key 的个数，默认为 1，改为较大值可以显著提升同步效率，同时也会提升源端压力。
+* `scan_max_queue_len`：仅对 SCAN 阶段生效。当内部待 DUMP 队列长度达到该阈值时，RedisShake 会暂停继续执行 SCAN；当队列长度回落到阈值以下后会自动恢复。`ksn` 订阅不受影响。设置为 `0` 表示关闭该背压机制。

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"RedisShake/internal/client"
 	"RedisShake/internal/client/proto"
@@ -31,6 +32,7 @@ type ScanReaderOptions struct {
 	DBS             []int            `mapstructure:"dbs"`
 	PreferReplica   bool             `mapstructure:"prefer_replica" default:"false"`
 	Count           int              `mapstructure:"count" default:"1"`
+	ScanMaxQueueLen int              `mapstructure:"scan_max_queue_len" default:"0"`
 	SkipUnknownType []string         `mapstructure:"skip_unknown_type" default:"[]"`
 }
 
@@ -54,6 +56,7 @@ type scanStandaloneReader struct {
 	dumpClient      *client.Redis
 	subWG           sync.WaitGroup
 	isValkey        bool
+	queueLen        func() int
 
 	stat struct {
 		Name              string `json:"name"`
@@ -73,8 +76,41 @@ func NewScanStandaloneReader(ctx context.Context, opts *ScanReaderOptions) Reade
 	r.stat.Name = "reader_" + strings.Replace(opts.Address, ":", "_", -1)
 	r.needDumpQueue = utils.NewUniqueQueue(100000000)     // cache 100000000 keys
 	r.needRestoreChan = make(chan *needRestoreItem, 1024) // inflight 1024 keys
+	r.queueLen = r.needDumpQueue.Len
 	log.Infof("[%s] scanStandaloneReader init finished. dbs=[%v]", r.stat.Name, r.dbs)
 	return r
+}
+
+func (r *scanStandaloneReader) getQueueLen() int {
+	if r.queueLen != nil {
+		return r.queueLen()
+	}
+	return 0
+}
+
+func (r *scanStandaloneReader) waitForScanQueueCapacity(dbId int) bool {
+	if r.opts.ScanMaxQueueLen <= 0 {
+		return true
+	}
+
+	backpressureLogged := false
+	for r.getQueueLen() >= r.opts.ScanMaxQueueLen {
+		if !backpressureLogged {
+			log.Infof("[%s] scan backpressure activated. queue_len=[%d], scan_max_queue_len=[%d], db=[%d]",
+				r.stat.Name, r.getQueueLen(), r.opts.ScanMaxQueueLen, dbId)
+			backpressureLogged = true
+		}
+		select {
+		case <-r.ctx.Done():
+			return false
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	if backpressureLogged {
+		log.Infof("[%s] scan backpressure released. queue_len=[%d], scan_max_queue_len=[%d], db=[%d]",
+			r.stat.Name, r.getQueueLen(), r.opts.ScanMaxQueueLen, dbId)
+	}
+	return true
 }
 
 func (r *scanStandaloneReader) StartRead(ctx context.Context) []chan *entry.Entry {
@@ -180,6 +216,11 @@ func (r *scanStandaloneReader) scan() {
 				r.needDumpQueue.Close()
 				return
 			default:
+			}
+			if !r.waitForScanQueueCapacity(dbId) {
+				log.Infof("[%s] scanStandaloneReader scan finished.", r.stat.Name)
+				r.needDumpQueue.Close()
+				return
 			}
 
 			var keys []string

--- a/internal/reader/scan_standalone_reader_test.go
+++ b/internal/reader/scan_standalone_reader_test.go
@@ -1,0 +1,62 @@
+package reader
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_scanStandaloneReader_waitForScanQueueCapacity(t *testing.T) {
+	var queueLen atomic.Int64
+	queueLen.Store(3)
+
+	r := &scanStandaloneReader{
+		ctx: context.Background(),
+		opts: &ScanReaderOptions{
+			ScanMaxQueueLen: 2,
+		},
+		queueLen: func() int {
+			return int(queueLen.Load())
+		},
+	}
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- r.waitForScanQueueCapacity(10)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("waitForScanQueueCapacity returned before queue length dropped below threshold")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	queueLen.Store(1)
+
+	select {
+	case ok := <-done:
+		require.True(t, ok)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("waitForScanQueueCapacity did not resume after queue length dropped below threshold")
+	}
+}
+
+func Test_scanStandaloneReader_waitForScanQueueCapacity_ContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := &scanStandaloneReader{
+		ctx: ctx,
+		opts: &ScanReaderOptions{
+			ScanMaxQueueLen: 1,
+		},
+		queueLen: func() int {
+			return 1
+		},
+	}
+
+	require.False(t, r.waitForScanQueueCapacity(10))
+}

--- a/shake.toml
+++ b/shake.toml
@@ -19,6 +19,7 @@ try_diskless = false       # Set to true for diskless sync if the source has rep
 #scan = true                # set to false if you don't want to scan keys
 #ksn = false                # set to true to enabled Redis keyspace notifications (KSN) subscription
 #count = 1                  # number of keys to scan per iteration
+#scan_max_queue_len = 0     # pause SCAN when the internal dump queue reaches this length, 0 disables backpressure
 ## RedisShake uses the TYPE command to get each key's type.
 ## If the type is in this skip list, the key will be skipped.
 #skip_unknown_type = []  # e.g. ["imset", "mbloom", "string", "hash", "list", "set", "zset"]


### PR DESCRIPTION
## Summary
- add  for  to pause SCAN when the internal dump queue reaches a configured threshold
- keep KSN subscription behavior unchanged while SCAN is paused
- document the new option and add reader unit tests covering pause/resume behavior

## Testing
- go test ./internal/reader/...
