### PR TITLE
fix: prevent writer deadlock on oversized RDB values

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -217,17 +217,22 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 			teeReader := io.TeeReader(rd, &value)
 			o := types.ParseObject(teeReader, typeByte, key, ld.isValkey)
 
-			// Rewrite() triggers the actual data reading from teeReader
+			// Rewrite() reads from teeReader in a goroutine. Drain the channel
+			// fully before checking value.Len(), otherwise value is still being
+			// populated and the size check reads 0 — letting oversized values
+			// slip through into RESTORE and blow up the target querybuf.
 			cmdC := o.Rewrite()
+			var cmds [][]string
+			for cmd := range cmdC {
+				cmds = append(cmds, cmd)
+			}
 
-			// Check if dump size exceeds limit
 			// dump size = typeByte(1) + value + version(2) + crc(8)
 			dumpSize := uint64(1 + value.Len() + 2 + 8)
 			if dumpSize > config.Opt.Advanced.TargetRedisProtoMaxBulkLen {
 				log.Warnf("key=[%s] dump size=[%d] exceeds target_redis_proto_max_bulk_len, falling back to individual commands. "+
 					"rdb_restore_command_behavior setting may not work correctly for this key.", key, dumpSize)
-				// Use the commands from Rewrite()
-				for cmd := range cmdC {
+				for _, cmd := range cmds {
 					e := entry.NewEntry()
 					e.DbId = ld.nowDBId
 					e.Argv = cmd
@@ -240,10 +245,6 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 					ld.ch <- e
 				}
 			} else {
-				// Drain the channel to ensure data is fully read
-				for range cmdC {
-				}
-				// Use RESTORE command
 				pttl := 0
 				if ld.expireMs > 0 {
 					pttl = int(ld.expireMs)

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -123,8 +123,18 @@ func (w *redisStandaloneWriter) processWrite(ctx context.Context) {
 			}
 			// send
 			bytes := e.Serialize()
-			for e.SerializedSize+atomic.LoadInt64(&w.stat.UnansweredBytes) > config.Opt.Advanced.TargetRedisClientMaxQuerybufLen {
-				time.Sleep(1 * time.Nanosecond)
+			// Wait only while target has in-flight bytes; otherwise a single oversized
+			// entry would spin forever (processReply can't drain what it never gets).
+			for unanswered := atomic.LoadInt64(&w.stat.UnansweredBytes); unanswered > 0 && e.SerializedSize+unanswered > config.Opt.Advanced.TargetRedisClientMaxQuerybufLen; unanswered = atomic.LoadInt64(&w.stat.UnansweredBytes) {
+				time.Sleep(time.Millisecond)
+			}
+			if e.SerializedSize > config.Opt.Advanced.TargetRedisClientMaxQuerybufLen {
+				key := ""
+				if len(e.Keys) > 0 {
+					key = e.Keys[0]
+				}
+				log.Warnf("[%s] entry serialized size=%d exceeds target_redis_client_max_querybuf_len=%d, sending anyway. cmd=[%s] key=[%s]",
+					w.stat.Name, e.SerializedSize, config.Opt.Advanced.TargetRedisClientMaxQuerybufLen, e.CmdName, key)
 			}
 			rl.Take()
 			log.Debugf("[%s] send cmd. cmd=[%s]", w.stat.Name, e.String())


### PR DESCRIPTION
Fix a race in the RDB parser where `value.Len()` was read before `o.Rewrite()`'s goroutine populated the buffer, letting oversized values slip past `target_redis_proto_max_bulk_len` into a single RESTORE and deadlocking the writer. Also harden `processWrite` so a single oversized entry can no longer spin forever on the querybuf throttle.