### PR TITLE
fix: use FUNCTION LOAD REPLACE when restoring function libraries

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -145,7 +145,7 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 			function := structure.ReadString(rd)
 			log.Debugf("function: %s", function)
 			e := entry.NewEntry()
-			e.Argv = []string{"function", "load", function}
+			e.Argv = []string{"function", "load", "replace", function}
 			ld.ch <- e
 		case kFlagModuleAux:
 			moduleId := structure.ReadLength(rd) // module id

--- a/tests/cases/function_library.py
+++ b/tests/cases/function_library.py
@@ -1,0 +1,66 @@
+import pybbt
+
+import helpers as h
+from helpers.constant import REDIS_SERVER_VERSION
+
+
+SRC_LIB = """#!lua name=mylib
+redis.register_function('myfunc', function() return 'src_version' end)
+"""
+
+DST_LIB = """#!lua name=mylib
+redis.register_function('myfunc', function() return 'dst_version' end)
+"""
+
+
+@pybbt.case()
+def test_function_library_rdb_replace_existing():
+    """RDB sync must overwrite a function library that already exists on dst.
+
+    Reproduces issue #1044: without REPLACE, FUNCTION LOAD fails with
+    "ERR Library 'mylib' already exists" when dst already holds the library
+    (e.g. after a redis-shake restart or retry).
+    """
+    if REDIS_SERVER_VERSION < 7.0:
+        return
+
+    src = h.Redis()
+    dst = h.Redis()
+
+    src.do("function", "load", SRC_LIB)
+    pybbt.ASSERT_TRUE(src.do("save"))
+
+    dst.do("function", "load", DST_LIB)
+    pybbt.ASSERT_EQ(dst.do("fcall", "myfunc", 0), b"dst_version")
+
+    opts = h.ShakeOpts.create_rdb_opts(f"{src.dir}/dump.rdb", dst)
+    pybbt.log(f"opts: {opts}")
+    h.Shake.run_once(opts)
+
+    pybbt.ASSERT_EQ(dst.do("fcall", "myfunc", 0), b"src_version")
+
+
+@pybbt.case()
+def test_function_library_sync_replace_existing():
+    """Same as the RDB case, but exercising the sync_reader path."""
+    if REDIS_SERVER_VERSION < 7.0:
+        return
+
+    src = h.Redis()
+    dst = h.Redis()
+
+    src.do("function", "load", SRC_LIB)
+    dst.do("function", "load", DST_LIB)
+
+    opts = h.ShakeOpts.create_sync_opts(src, dst)
+    pybbt.log(f"opts: {opts}")
+    shake = h.Shake(opts)
+
+    try:
+        shake.wait_for_sync(timeout=10)
+    except Exception as e:
+        with open(f"{shake.dir}/data/shake.log") as f:
+            pybbt.log(f.read())
+        raise e
+
+    pybbt.ASSERT_EQ(dst.do("fcall", "myfunc", 0), b"src_version")


### PR DESCRIPTION
## Summary

- Append `REPLACE` when emitting `FUNCTION LOAD` from RDB-parsed function library entries, so sync no longer aborts when the destination already holds the same library (e.g. after a redis-shake restart, retry, or against a previously-synced destination).
- Add black-box tests covering both the RDB reader and sync reader code paths. Tests pre-load a different library with the same name on dst, then verify dst ends up with src's version after sync.

## Why

Reported in #1044: Valkey-to-Valkey function sync fails with:

```
ERR [writer_127.0.0.1_7013] receive reply failed. cmd=[function load #!lua name=mylib ...], error=[ERR Library 'mylib' already exists]
```

In a sync context the source is authoritative and functions are code (not user data), so unconditionally replacing matches both Valkey/Redis's own internal replication semantics (`FUNCTION RESTORE FLUSH`) and user expectations.

## Test plan

- [x] `go build ./...`
- [x] New test `tests/cases/function_library.py` (`test_function_library_rdb_replace_existing`, `test_function_library_sync_replace_existing`) passes locally with the fix applied.
- [x] Verified the new RDB test fails when the fix is reverted (assertion: dst still returns `dst_version` instead of `src_version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)