### PR TITLE
fix: AOF reader truncates RESP bulk strings on embedded CRLF

### DIFF
--- a/internal/aof/aof.go
+++ b/internal/aof/aof.go
@@ -130,21 +130,22 @@ func (ld *Loader) LoadSingleAppendOnlyFile(ctx context.Context, timestamp int64)
 
 			for j := 0; j < int(argc); j++ {
 				line, err := ReadCompleteLine(reader)
-				if err != nil || line[0] != '$' {
+				if err != nil || len(line) == 0 || line[0] != '$' {
 					log.Infof("Bad File format reading the append only File %v:make a backup of your AOF File, then use ./redis-check-AOF --fix <FileName.manifest>", filePath)
 					ret = Failed
 					return ret
 				}
 				v64, _ := strconv.ParseInt(string(line[1:]), 10, 64)
-				var argString []byte
-				argString, err = ReadCompleteLine(reader)
-				if err != nil {
+				// Read exactly v64 bytes plus the trailing CRLF. The argument
+				// payload may contain '\r' or '\n' (e.g. binary RDB dumps in
+				// RESTORE commands), so a line-based read would truncate it.
+				buf := make([]byte, v64+2)
+				if _, err := io.ReadFull(reader, buf); err != nil {
 					log.Infof("Unrecoverable error reading the append only File %v: %v", filePath, err)
 					ret = Failed
 					return ret
 				}
-				argString = argString[:v64]
-				argv = append(argv, string(argString))
+				argv = append(argv, string(buf[:v64]))
 			}
 			e.Argv = append(e.Argv, argv...)
 			ld.ch <- e

--- a/internal/aof/aof_test.go
+++ b/internal/aof/aof_test.go
@@ -1,0 +1,132 @@
+package aof
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"RedisShake/internal/entry"
+)
+
+// writeRESP encodes args as a RESP2 array (`*N\r\n$len\r\n<arg>\r\n...`).
+func writeRESP(buf *bytes.Buffer, args ...string) {
+	buf.WriteString("*")
+	buf.WriteString(itoa(len(args)))
+	buf.WriteString("\r\n")
+	for _, a := range args {
+		buf.WriteString("$")
+		buf.WriteString(itoa(len(a)))
+		buf.WriteString("\r\n")
+		buf.WriteString(a)
+		buf.WriteString("\r\n")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+func writeAOF(t *testing.T, content []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.aof")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write aof: %v", err)
+	}
+	return path
+}
+
+func loadAll(t *testing.T, path string) []*entry.Entry {
+	t.Helper()
+	ch := make(chan *entry.Entry, 1024)
+	ld := NewLoader(path, ch)
+	done := make(chan int, 1)
+	go func() {
+		done <- ld.LoadSingleAppendOnlyFile(context.Background(), 0)
+		close(ch)
+	}()
+	var entries []*entry.Entry
+	for e := range ch {
+		entries = append(entries, e)
+	}
+	select {
+	case ret := <-done:
+		if ret != OK {
+			t.Fatalf("LoadSingleAppendOnlyFile returned %d", ret)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("loader did not finish in time")
+	}
+	return entries
+}
+
+// TestLoadSingleAppendOnlyFile_BinaryArgWithCRLF reproduces issue #1046:
+// a RESTORE-style command whose binary payload contains '\r\n' must round-trip
+// correctly. Before the fix, the line-based reader truncated the value at the
+// embedded CRLF and either panicked or desynced the stream.
+func TestLoadSingleAppendOnlyFile_BinaryArgWithCRLF(t *testing.T) {
+	binary := []byte{0x00, 0x05, 'a', '\r', '\n', 'b', 'c', 0xff, 0x0a, 0x0d, 0x42}
+	var buf bytes.Buffer
+	writeRESP(&buf, "RESTORE", "key", "0", string(binary))
+	writeRESP(&buf, "SET", "next", "ok")
+
+	entries := loadAll(t, writeAOF(t, buf.Bytes()))
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if got := entries[0].Argv; len(got) != 4 || got[0] != "RESTORE" || got[1] != "key" || got[2] != "0" || got[3] != string(binary) {
+		t.Fatalf("RESTORE entry mismatch: %#v", got)
+	}
+	if got := entries[1].Argv; len(got) != 3 || got[0] != "SET" || got[1] != "next" || got[2] != "ok" {
+		t.Fatalf("SET entry mismatch: %#v", got)
+	}
+}
+
+func TestLoadSingleAppendOnlyFile_EmptyArg(t *testing.T) {
+	var buf bytes.Buffer
+	writeRESP(&buf, "SET", "key", "")
+
+	entries := loadAll(t, writeAOF(t, buf.Bytes()))
+
+	if len(entries) != 1 || len(entries[0].Argv) != 3 || entries[0].Argv[2] != "" {
+		t.Fatalf("empty-value entry mismatch: %#v", entries)
+	}
+}
+
+func TestLoadSingleAppendOnlyFile_PlainCommands(t *testing.T) {
+	var buf bytes.Buffer
+	writeRESP(&buf, "SET", "k1", "v1")
+	writeRESP(&buf, "SET", "k2", "v2")
+
+	entries := loadAll(t, writeAOF(t, buf.Bytes()))
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Argv[2] != "v1" || entries[1].Argv[2] != "v2" {
+		t.Fatalf("entries mismatch: %#v", entries)
+	}
+}


### PR DESCRIPTION
## Summary

`LoadSingleAppendOnlyFile` reads each RESP bulk-string payload with `ReadCompleteLine` (which stops at `\r\n` or `\n`) and then slices `argString[:v64]`. When the payload itself contains those bytes — e.g. a binary RDB dump in a `RESTORE` command produced by `file_writer type=aof` — the read returns a truncated buffer and either:

- panics on `argString[:v64]` (slice bounds out of range), or
- leaves the stream offset wrong, so a later `ReadCompleteLine` returns an empty line and the next `line[0]` indexing panics.

Fix by reading exactly `v64 + 2` bytes (payload + CRLF) with `io.ReadFull`, matching how `internal/client/proto/reader.go` reads bulk strings. Also guards the `$` header check against an empty line from malformed input.

## Why

Reported in #1046: `scan_reader → file_writer (type=aof)` then `aof_reader → redis_writer` round-trip fails with `Bad File format reading the append only File ...`. Reproduced locally with ~500 random keys (binary RDB dumps frequently contain `\r`/`\n` byte values); after the fix, the round-trip syncs cleanly.

A drive-by reason this was missed: every `tests/cases/aof.py` case is currently `@pybbt.case(skip=True)`, and even the non-skipped tests use plain ASCII values that never expose the bug.

## Test plan

- [x] `go test ./internal/aof/` — three new unit tests cover the binary-CRLF case, an empty bulk string, and the plain ASCII case.
- [x] Verified the new `TestLoadSingleAppendOnlyFile_BinaryArgWithCRLF` fails (panic) when the fix is reverted.
- [x] End-to-end repro: started two local Redis instances, populated src with 500 random-hex string keys + a hash, ran `scan_reader → file_writer type=aof` then `aof_reader → redis_writer`. Before fix: `panic: index out of range [0]`. After fix: `src dbsize: 501, dst dbsize: 501`, `HGETALL` matches semantically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)