### PR TITLE
test: bump wait_for_sync timeout from 10s to 60s

### DIFF
--- a/tests/cases/auth_acl.py
+++ b/tests/cases/auth_acl.py
@@ -31,7 +31,7 @@ def test_acl():
     shake = h.Shake(opts)
 
     # wait sync done
-    shake.wait_for_sync(timeout=10)
+    shake.wait_for_sync(timeout=60)
     pybbt.log(shake.get_status())
 
     # check data

--- a/tests/cases/function.py
+++ b/tests/cases/function.py
@@ -26,7 +26,7 @@ def test_filter_db():
         src.do("set", "key", "value")
 
     # wait sync done (use db=1 because db=0 is filtered)
-    shake.wait_for_sync(timeout=10, db=1)
+    shake.wait_for_sync(timeout=60, db=1)
 
     dst.do("select", 0)
     pybbt.ASSERT_EQ(dst.do("get", "key"), None)

--- a/tests/cases/function_library.py
+++ b/tests/cases/function_library.py
@@ -57,7 +57,7 @@ def test_function_library_sync_replace_existing():
     shake = h.Shake(opts)
 
     try:
-        shake.wait_for_sync(timeout=10)
+        shake.wait_for_sync(timeout=60)
     except Exception as e:
         with open(f"{shake.dir}/data/shake.log") as f:
             pybbt.log(f.read())

--- a/tests/cases/sync.py
+++ b/tests/cases/sync.py
@@ -18,8 +18,7 @@ def _test_sync(src, dst):
     pybbt.log(f"opts: {opts}")
     shake = h.Shake(opts)
 
-    # Use longer timeout for cluster sync (cluster gossip and cross-node sync takes more time)
-    sync_timeout = 30 if (src.is_cluster() or dst.is_cluster()) else 10
+    sync_timeout = 60
 
     # wait sync done
     try:

--- a/tests/helpers/shake.py
+++ b/tests/helpers/shake.py
@@ -135,7 +135,7 @@ class Shake:
     def is_consistent(self):
         return self.get_status()["consistent"]
 
-    def wait_for_sync(self, timeout: float = 5, db: int = 0):
+    def wait_for_sync(self, timeout: float = 60, db: int = 0):
         """
         Wait for data to be fully synced from src to dst.
 


### PR DESCRIPTION
## Summary

The single `Timer` in `wait_for_sync` is shared across all 6 sync-verification steps. On slow GitHub Actions runners, the initial `is_consistent()` wait (RDB sync + module load) consumes the whole 10s budget, leaving the trailing marker-key checks with effectively no time. The most recent CI failure showed only ~2ms between the final marker delete and the timeout trigger.

This causes flaky `TimeoutError: marker key not deleted within 10s` failures — 4 of the last 30 CI runs failed with this exact error (~13% flake rate).

Raising the per-call budget from 10s → 60s gives every step ample headroom without slowing down healthy runs (which finish in seconds).

## Test plan

- [ ] CI passes on this branch
- [ ] Re-run CI once or twice to confirm stability