### PR TITLE
chore(ci): 更新 GitHub Actions 到 Node 24 兼容版本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
             fail-fast: false
         steps:
             -   name: Git checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
 
             -   name: Setup Golang with cache
-                uses: magnetikonline/action-golang-cache@v5
+                uses: actions/setup-go@v6
                 with:
                     go-version-file: go.mod
 
             -   name: Cache Redis binary
                 id: cache-redis
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: redis/bin
                     key: redis-${{ matrix.redis-version }}-${{ runner.os }}-v1
@@ -46,7 +46,7 @@ jobs:
             -   name: Cache Tair Modules
                 id: cache-tair
                 if: contains('5.0, 6.0, 7.0, 8.0', matrix.redis-version)
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: tair-modules
                     key: tair-modules-${{ runner.os }}-v1
@@ -68,7 +68,7 @@ jobs:
                 run: sudo cp tair-modules/*.so /lib/
 
             -   name: Setup Python with cache
-                uses: actions/setup-python@v5
+                uses: actions/setup-python@v6
                 with:
                     python-version: '3.11'
                     cache: 'pip'
@@ -92,16 +92,16 @@ jobs:
             fail-fast: false
         steps:
             -   name: Git checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
 
             -   name: Setup Golang with cache
-                uses: magnetikonline/action-golang-cache@v5
+                uses: actions/setup-go@v6
                 with:
                     go-version-file: go.mod
 
             -   name: Cache Valkey binary
                 id: cache-valkey
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: valkey/bin
                     key: valkey-${{ matrix.valkey-version }}-${{ runner.os }}-v1
@@ -119,7 +119,7 @@ jobs:
                 run: echo "$GITHUB_WORKSPACE/valkey/bin" >> $GITHUB_PATH
 
             -   name: Setup Python with cache
-                uses: actions/setup-python@v5
+                uses: actions/setup-python@v6
                 with:
                     python-version: '3.11'
                     cache: 'pip'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,16 +14,16 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -39,7 +39,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,15 +29,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v3
+                uses: actions/checkout@v6
             -   name: Setup Node
-                uses: actions/setup-node@v3
+                uses: actions/setup-node@v6
                 with:
                     node-version: 18
                     cache: npm
                     cache-dependency-path: docs/package-lock.json
             -   name: Setup Pages
-                uses: actions/configure-pages@v3
+                uses: actions/configure-pages@v6
             -   name: Install dependencies
                 run: npm ci # or pnpm install / yarn install
                 working-directory: docs
@@ -45,7 +45,7 @@ jobs:
                 run: npm run docs:build # or pnpm docs:build / yarn docs:build
                 working-directory: docs
             -   name: Upload artifact
-                uses: actions/upload-pages-artifact@v3
+                uses: actions/upload-pages-artifact@v5
                 with:
                     path: docs/.vitepress/dist
 
@@ -60,4 +60,4 @@ jobs:
         steps:
             -   name: Deploy to GitHub Pages
                 id: deployment
-                uses: actions/deploy-pages@v4
+                uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,19 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
                 with:
                     fetch-depth: 0
 
             -   name: Setup Golang with cache
-                uses: magnetikonline/action-golang-cache@v4
+                uses: actions/setup-go@v6
                 with:
                     go-version-file: go.mod
 
             -   name: "Draft release"
                 id: "release"
                 if: github.event_name == 'workflow_dispatch'
-                uses: release-drafter/release-drafter@v6
+                uses: release-drafter/release-drafter@v7
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -86,7 +86,7 @@ jobs:
                     ls -la redis-shake-${VERSION}-*.tar.gz
 
             -   name: Upload Release Assets
-                uses: softprops/action-gh-release@v1
+                uses: softprops/action-gh-release@v3
                 with:
                     # For tag-triggered builds, these will be auto-detected
                     # For manual builds, use release drafter outputs


### PR DESCRIPTION
## 背景

GitHub Actions 已开始弃用 Node.js 20 action runtime：

- [GitHub Changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)：runner 将从 2026-06-02 起默认使用 Node.js 24。
- [RedisShake CI warning](https://github.com/tair-opensource/RedisShake/actions/runs/25836803705)：Node.js 20 将在 2026-09-16 从 runner 移除。

本 PR 将 RedisShake workflow 使用的 actions 升级到 Node.js 24 兼容版本。

## 改动

- 升级 GitHub 官方 actions 到 Node 24 兼容版本，例如 `checkout@v6`、`setup-go@v6`、`setup-python@v6`、`cache@v5`。
- 将 `magnetikonline/action-golang-cache` 替换为 `setup-go@v6` 内建 cache。
- 同步更新 pages、release、docker workflow 里相关的第三方 actions。

## Cache 行为变化

`magnetikonline/action-golang-cache` 仍封装了旧版 `setup-go` / `cache` action；切到 `setup-go@v6` 内建 cache 后，可以直接使用官方 Node 24 兼容 action，并减少一层第三方封装。

这会带来以下 cache 行为差异：

- 缓存内容不变：仍缓存 `GOMODCACHE` 和 `GOCACHE`。
- cache key 更细：从 `Linux-golang-${hash(**/go.sum)}` 变为包含 OS、架构、runner image、Go 版本和默认 `go.sum` hash 的 key。
- dependency path 使用默认值：`setup-go@v6` 默认读取仓库根目录 `go.sum`；RedisShake 当前只有这一个 `go.sum`，所以无需显式配置。
- restore 更保守：不再用 `Linux-golang-` 这类宽泛前缀回退，首次命中率可能降低，但更不容易复用到不匹配的旧 cache。

构建和测试命令不变；Go 版本来源仍是 `go.mod`，cache 也沿用 `setup-go@v6` 的默认开启行为。如果后续引入多个 Go module，再补 `cache-dependency-path: '**/go.sum'` 即可。
