### PR TITLE
chore!: 升级 Go 至 1.26 并适配 go vet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module RedisShake
 
-go 1.21
+go 1.26
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/internal/client/func.go
+++ b/internal/client/func.go
@@ -18,7 +18,7 @@ func EncodeArgv(argv []string, buf *bytes.Buffer) {
 	}
 	err := writer.WriteArgs(argvInterface)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 }
 

--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -177,7 +177,7 @@ func (r *Redis) DoWithStringReply(args ...interface{}) string {
 
 	replyInterface, err := r.Receive()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	reply := replyInterface.(string)
 	return reply
@@ -188,7 +188,7 @@ func (r *Redis) Do(args ...interface{}) interface{} {
 
 	reply, err := r.Receive()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	return reply
 }
@@ -200,7 +200,7 @@ func (r *Redis) Send(args ...interface{}) {
 	}
 	err := r.protoWriter.WriteArgs(argsInterface)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	r.Flush()
 }
@@ -209,14 +209,14 @@ func (r *Redis) Send(args ...interface{}) {
 func (r *Redis) SendBytesBuff(buf []byte) {
 	_, err := r.writer.Write(buf)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 }
 
 func (r *Redis) Flush() {
 	err := r.writer.Flush()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 }
 
@@ -227,7 +227,7 @@ func (r *Redis) Receive() (interface{}, error) {
 func (r *Redis) ReceiveString() string {
 	reply, err := r.Receive()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	return reply.(string)
 }
@@ -264,7 +264,7 @@ func (r *Redis) Scan(cursor uint64, count int) (newCursor uint64, keys []string)
 	r.Send("scan", strconv.FormatUint(cursor, 10), "count", count)
 	reply, err := r.Receive()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 
 	array := reply.([]interface{})
@@ -275,7 +275,7 @@ func (r *Redis) Scan(cursor uint64, count int) (newCursor uint64, keys []string)
 	// cursor
 	newCursor, err = strconv.ParseUint(array[0].(string), 10, 64)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	// keys
 	keys = make([]string, 0)

--- a/internal/client/reply.go
+++ b/internal/client/reply.go
@@ -4,7 +4,7 @@ import "RedisShake/internal/log"
 
 func ArrayString(replyInterface interface{}, err error) []string {
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	replyArray := replyInterface.([]interface{})
 	replyArrayString := make([]string, len(replyArray))

--- a/internal/commands/keys.go
+++ b/internal/commands/keys.go
@@ -79,7 +79,7 @@ func CalcKeys(argv []string) (cmaName string, group string, keys []string, keysI
 			}
 			keyCount, err := strconv.Atoi(argv[keynumIdx])
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			firstKey := spec.findKeysKeynumFirstKey
 			step := spec.findKeysKeynumKeyStep

--- a/internal/entry/entry.go
+++ b/internal/entry/entry.go
@@ -46,7 +46,7 @@ func (e *Entry) Serialize() []byte {
 	}
 	err := writer.WriteArgs(argvInterface)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	e.SerializedSize = int64(buf.Len())
 	return buf.Bytes()

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -89,7 +89,7 @@ func (ld *Loader) ParseRDB(ctx context.Context) int {
 	buf := make([]byte, 9)
 	_, err = io.ReadFull(rd, buf)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	var version int
 	if bytes.Equal(buf[:5], []byte("REDIS")) {
@@ -104,7 +104,7 @@ func (ld *Loader) ParseRDB(ctx context.Context) int {
 		log.Panicf("verify magic string, invalid file format. bytes=[%v]", buf[:6])
 	}
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	log.Debugf("[%s] RDB version: %d", ld.name, version)
 
@@ -122,7 +122,7 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 		}
 		offset, err := ld.fp.Seek(0, io.SeekCurrent)
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		ld.updateFunc(offset)
 	}
@@ -180,7 +180,7 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 				var err error
 				ld.replStreamDbId, err = strconv.Atoi(value)
 				if err != nil {
-					log.Panicf(err.Error())
+					log.Panicf("%v", err)
 				}
 				log.Debugf("[%s] RDB repl-stream-db: [%s]", ld.name, value)
 			} else if key == "lua" {

--- a/internal/rdb/structure/byte.go
+++ b/internal/rdb/structure/byte.go
@@ -15,7 +15,7 @@ func ReadBytes(rd io.Reader, n int) []byte {
 	buf := make([]byte, n)
 	_, err := io.ReadFull(rd, buf)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	return buf
 }

--- a/internal/rdb/structure/float.go
+++ b/internal/rdb/structure/float.go
@@ -28,7 +28,7 @@ func ReadFloat(rd io.Reader) float64 {
 
 		v, err := strconv.ParseFloat(string(buf), 64)
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		return v
 	}
@@ -38,7 +38,7 @@ func ReadDouble(rd io.Reader) float64 {
 	var buf = make([]byte, 8)
 	_, err := io.ReadFull(rd, buf)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	num := binary.LittleEndian.Uint64(buf)
 	return math.Float64frombits(num)

--- a/internal/rdb/structure/length.go
+++ b/internal/rdb/structure/length.go
@@ -23,7 +23,7 @@ func ReadLength(rd io.Reader) uint64 {
 		log.Panicf("illegal length special=true, encoding: %d", length)
 	}
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	return length
 }

--- a/internal/rdb/structure/string.go
+++ b/internal/rdb/structure/string.go
@@ -17,7 +17,7 @@ const (
 func ReadString(rd io.Reader) string {
 	length, special, err := readEncodedLength(rd)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	if special {
 		switch length {

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -99,7 +99,7 @@ func (r *scanStandaloneReader) subscribe() {
 		c.Send("psubscribe", "__keyevent@*__:*")
 		_, err := c.Receive()
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 	} else {
 		args := []interface{}{"psubscribe"}
@@ -110,7 +110,7 @@ func (r *scanStandaloneReader) subscribe() {
 		for range r.dbs {
 			_, err := c.Receive()
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 		}
 	}
@@ -128,14 +128,14 @@ func (r *scanStandaloneReader) subscribe() {
 		default:
 			resp, err := c.Receive()
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			respSlice := resp.([]interface{})
 			key := respSlice[3].(string)
 			dbId := regex.FindString(respSlice[2].(string))
 			dbIdInt, err := strconv.Atoi(dbId)
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			// handle del action
 			eventSlice := strings.Split(respSlice[2].(string), ":")
@@ -159,7 +159,7 @@ func (r *scanStandaloneReader) scan() {
 		c.Send("info", "keyspace")
 		info, err := c.Receive()
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		dbs = utils.ParseDBs(info.(string))
 	}
@@ -256,7 +256,7 @@ func (r *scanStandaloneReader) restore() {
 		if len(r.opts.SkipUnknownType) > 0 {
 			iType, err3 := r.dumpClient.Receive()
 			if err3 != nil {
-				log.Panicf(err3.Error())
+				log.Panicf("%v", err3)
 			}
 			typeStr := iType.(string)
 			// type in SkipUnknownType
@@ -274,9 +274,9 @@ func (r *scanStandaloneReader) restore() {
 		if errors.Is(err1, proto.Nil) {
 			continue // key not exist
 		} else if err1 != nil {
-			log.Panicf(err1.Error())
+			log.Panicf("%v", err1)
 		} else if err2 != nil {
-			log.Panicf(err2.Error())
+			log.Panicf("%v", err2)
 		}
 		dump := iDump.(string)
 		pttl := 0

--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -267,7 +267,7 @@ func (r *syncStandaloneReader) sendPSync() {
 		}
 		peakByte, err := r.client.Peek()
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		if peakByte != '\n' {
 			break
@@ -280,7 +280,7 @@ func (r *syncStandaloneReader) sendPSync() {
 	reply := r.client.ReceiveString()
 	masterOffset, err := strconv.Atoi(strings.Split(reply, " ")[2])
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	r.stat.AofReceivedOffset = int64(masterOffset)
 }
@@ -324,7 +324,7 @@ func (r *syncStandaloneReader) sendSync() {
 		}
 		peekByte, err := r.client.Peek()
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		if peekByte != '\n' {
 			break
@@ -345,7 +345,7 @@ func (r *syncStandaloneReader) receiveRDB() string {
 	for {
 		b, err := r.client.ReadByte()
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		if b == '\n' { // heartbeat
 			continue
@@ -358,7 +358,7 @@ func (r *syncStandaloneReader) receiveRDB() string {
 	log.Debugf("[%s] source db bgsave finished. timeUsed=[%.2f]s", r.stat.Name, time.Since(timeStart).Seconds())
 	marker, err := r.client.ReadString('\n')
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	marker = strings.TrimSpace(marker)
 
@@ -380,13 +380,13 @@ func (r *syncStandaloneReader) receiveRDB() string {
 	// create rdb file
 	rdbFilePath, err := filepath.Abs(r.stat.Name + "/dump.rdb")
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	timeStart = time.Now()
 	log.Debugf("[%s] start receiving RDB. path=[%s]", r.stat.Name, rdbFilePath)
 	rdbFileHandle, err := os.OpenFile(rdbFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 
 	// receive rdb
@@ -398,7 +398,7 @@ func (r *syncStandaloneReader) receiveRDB() string {
 	}
 	err = rdbFileHandle.Close()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	log.Debugf("[%s] save RDB finished. timeUsed=[%.2f]s", r.stat.Name, time.Since(timeStart).Seconds())
 	return rdbFilePath
@@ -420,7 +420,7 @@ func (r *syncStandaloneReader) receiveRDBWithDiskless(marker string, wt io.Write
 
 		nread, err := r.client.Read(buf[len(lastBytes):])
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 
 		bufLen := len(lastBytes) + nread
@@ -429,7 +429,7 @@ func (r *syncStandaloneReader) receiveRDBWithDiskless(marker string, wt io.Write
 			log.Infof("meet EOF end marker.")
 			// Write all buf without EOF marker and break
 			if nwrite, err = wt.Write(buf[:bufLen-RDB_EOF_MARKER_LEN]); err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			break
 		}
@@ -437,7 +437,7 @@ func (r *syncStandaloneReader) receiveRDBWithDiskless(marker string, wt io.Write
 		if bufLen >= RDB_EOF_MARKER_LEN {
 			// left RDB_EOF_MARKER_LEN bytes to next round
 			if nwrite, err = wt.Write(buf[:bufLen-RDB_EOF_MARKER_LEN]); err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			lastBytes = buf[bufLen-RDB_EOF_MARKER_LEN : bufLen] // save last RDB_EOF_MARKER_LEN bytes into lastBytes for next round
 		} else {
@@ -453,7 +453,7 @@ func (r *syncStandaloneReader) receiveRDBWithDiskless(marker string, wt io.Write
 func (r *syncStandaloneReader) receiveRDBWithoutDiskless(marker string, wt io.Writer) {
 	length, err := strconv.ParseInt(marker, 10, 64)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	log.Debugf("[%s] rdb file size: [%v]", r.stat.Name, humanize.IBytes(uint64(length)))
 	r.stat.RdbFileSizeBytes = uint64(length)
@@ -468,12 +468,12 @@ func (r *syncStandaloneReader) receiveRDBWithoutDiskless(marker string, wt io.Wr
 		}
 		n, err := r.client.Read(buf[:readOnce])
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		remainder -= int64(n)
 		_, err = wt.Write(buf[:n])
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 
 		r.stat.RdbReceivedBytes += uint64(n)
@@ -492,7 +492,7 @@ func (r *syncStandaloneReader) receiveAOF() {
 		default:
 			n, err := r.client.Read(buf)
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			r.stat.AofReceivedBytes += uint64(n)
 			aofWriter.Write(buf[:n])
@@ -540,7 +540,7 @@ func (r *syncStandaloneReader) sendAOF(offset int64) {
 		if strings.EqualFold(argv[0], "select") {
 			DbId, err := strconv.Atoi(argv[1])
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 			r.DbId = DbId
 			continue

--- a/internal/status/handler.go
+++ b/internal/status/handler.go
@@ -43,7 +43,7 @@ func setStatusPort() {
 		go func() {
 			addr := fmt.Sprintf(":%d", config.Opt.Advanced.StatusPort)
 			if err := http.ListenAndServe(addr, http.HandlerFunc(Handler)); err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 		}()
 		log.Infof("status information: http://localhost:%v", config.Opt.Advanced.StatusPort)

--- a/internal/utils/cluster_nodes.go
+++ b/internal/utils/cluster_nodes.go
@@ -32,7 +32,7 @@ func GetRedisClusterNodes(ctx context.Context, address string, username string, 
 
 		// address
 		address := strings.Split(words[1], "@")[0]
-		
+
 		// handle ipv6 address
 		tok := strings.Split(address, ":")
 		if len(tok) > 2 {
@@ -42,13 +42,13 @@ func GetRedisClusterNodes(ctx context.Context, address string, username string, 
 			ipv6Addr := strings.Join(tok[:len(tok)-1], ":")
 			address = fmt.Sprintf("[%s]:%s", ipv6Addr, port)
 		}
-		
+
 		// handle hostname
-		hostname := strings.Split(words[1],",")
+		hostname := strings.Split(words[1], ",")
 		if len(hostname) > 1 {
-                        address = fmt.Sprintf("%s:%s", hostname[1], tok[len(tok)-1])
-                }
-		
+			address = fmt.Sprintf("%s:%s", hostname[1], tok[len(tok)-1])
+		}
+
 		if isMaster && len(words) < 9 {
 			log.Warnf("the current master node does not hold any slots. address=[%v]", address)
 			continue
@@ -83,16 +83,16 @@ func GetRedisClusterNodes(ctx context.Context, address string, username string, 
 				seg := strings.Split(words[i], "-")
 				start, err = strconv.Atoi(seg[0])
 				if err != nil {
-					log.Panicf(err.Error())
+					log.Panicf("%v", err)
 				}
 				end, err = strconv.Atoi(seg[1])
 				if err != nil {
-					log.Panicf(err.Error())
+					log.Panicf("%v", err)
 				}
 			} else {
 				start, err = strconv.Atoi(words[i])
 				if err != nil {
-					log.Panicf(err.Error())
+					log.Panicf("%v", err)
 				}
 				end = start
 			}

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -27,7 +27,7 @@ func IsExist(path string) bool {
 		if os.IsNotExist(err) {
 			return false
 		} else {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 	}
 	return true
@@ -36,7 +36,7 @@ func IsExist(path string) bool {
 func GetFileSize(path string) uint64 {
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	return uint64(fi.Size())
 }
@@ -44,7 +44,7 @@ func GetFileSize(path string) uint64 {
 func GetAbsPath(path string) string {
 	absolutePath, err := filepath.Abs(path)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	return absolutePath
 }

--- a/internal/utils/file_rotate/aof_reader.go
+++ b/internal/utils/file_rotate/aof_reader.go
@@ -45,7 +45,7 @@ func (r *AOFReader) openFile(offset int64) {
 	var err error
 	r.file, err = os.OpenFile(r.filepath, os.O_RDONLY, 0644)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	r.offset = offset
 	r.pos = 0
@@ -83,7 +83,7 @@ func (r *AOFReader) Read(buf []byte) (n int, err error) {
 		r.readNextFile(r.offset) // try to read next file
 		_, err = r.file.Seek(0, 1)
 		if err != nil {
-			log.Panicf(err.Error())
+			log.Panicf("%v", err)
 		}
 		n, err = r.file.Read(buf)
 
@@ -96,7 +96,7 @@ func (r *AOFReader) Read(buf []byte) (n int, err error) {
 		}
 	}
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	r.offset += int64(n)
 	r.pos += int64(n)
@@ -113,7 +113,7 @@ func (r *AOFReader) Close() {
 	}
 	err := r.file.Close()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	r.file = nil
 	log.Debugf("[%s] close file. filename=[%s]", r.name, r.filepath)

--- a/internal/utils/file_rotate/aof_writer.go
+++ b/internal/utils/file_rotate/aof_writer.go
@@ -32,7 +32,7 @@ func (w *AOFWriter) openFile(offset int64) {
 	var err error
 	w.file, err = os.OpenFile(w.filepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	w.offset = offset
 	w.filesize = 0
@@ -42,7 +42,7 @@ func (w *AOFWriter) openFile(offset int64) {
 func (w *AOFWriter) Write(buf []byte) {
 	_, err := w.file.Write(buf)
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	w.offset += int64(len(buf))
 	w.filesize += int64(len(buf))
@@ -58,11 +58,11 @@ func (w *AOFWriter) Close() {
 	}
 	err := w.file.Sync()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	err = w.file.Close()
 	if err != nil {
-		log.Panicf(err.Error())
+		log.Panicf("%v", err)
 	}
 	log.Infof("[%s] close file. filename=[%s], filesize=[%d]", w.name, w.filepath, w.filesize)
 }

--- a/internal/utils/pprof.go
+++ b/internal/utils/pprof.go
@@ -14,7 +14,7 @@ func SetPprofPort() {
 		go func() {
 			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", config.Opt.Advanced.PprofPort), nil)
 			if err != nil {
-				log.Panicf(err.Error())
+				log.Panicf("%v", err)
 			}
 		}()
 		log.Infof("pprof information: http://localhost:%d/debug/pprof/", config.Opt.Advanced.PprofPort)


### PR DESCRIPTION
## 背景

我之前在 #1053 里讨论了一个后续可能探索的方向。前期调研时发现，如果继续推进这个方向，可能会涉及较新的第三方依赖，而这些依赖对 Go 工具链版本有更高要求。

为了避免后续功能 PR 同时混入依赖引入、Go 版本升级和大量 `go vet` 机械修改，这个 PR 先单独完成 Go 版本升级和现有代码的 vet 适配。

即使后续不继续推进 #1053 中讨论的方向，提前升级 Go 版本也有独立价值：项目可以使用更新的 Go 工具链，并提前消化高版本 `go vet` 的检查规则，降低后续维护和依赖升级成本。

## 改动内容

- 将 `go.mod` 的 Go 版本升级到 `1.26`。
- 将 Docker builder 镜像升级到 `golang:1.26-alpine`。
- 将 `log.Panicf(err.Error())` 这类非 const format string 调用改为 `log.Panicf("%v", err)`，适配新版 `go vet` 规则。

## BREAKING CHANGE

构建 RedisShake 需要使用 Go 1.26 或更高版本。运行时配置和业务行为不应发生变化。
