### PR TITLE
scan_reader: parallel dump + batched sends + bounded queue; redis_writer: parallel connections

### DIFF
--- a/internal/client/redis.go
+++ b/internal/client/redis.go
@@ -205,6 +205,21 @@ func (r *Redis) Send(args ...interface{}) {
 	r.Flush()
 }
 
+// SendNoFlush encodes a command into the write buffer WITHOUT flushing, so the
+// caller can pipeline many commands per syscall and Flush() in batches. (Send()
+// flushes per command — fine for request/reply, but a syscall-per-command
+// bottleneck for the scan reader's high-volume DUMP/PTTL stream.)
+func (r *Redis) SendNoFlush(args ...interface{}) {
+	argsInterface := make([]interface{}, len(args))
+	for inx, item := range args {
+		argsInterface[inx] = item
+	}
+	err := r.protoWriter.WriteArgs(argsInterface)
+	if err != nil {
+		log.Panicf("%v", err)
+	}
+}
+
 // SendBytesBuff send bytes to buffer, need to call Flush() to send the buffer
 func (r *Redis) SendBytesBuff(buf []byte) {
 	_, err := r.writer.Write(buf)

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -61,6 +61,54 @@ type Loader struct {
 	isValkey   bool // true if reading a Valkey RDB (VALKEY magic string)
 }
 
+// rdbDumpFrameLen is the framing a DUMP/RESTORE payload adds around the raw value:
+// typeByte(1) + RDB version(2) + crc64(8).
+const rdbDumpFrameLen = 11
+
+// cappedValueBuffer captures an object's raw RDB bytes for the single-RESTORE fast path, but
+// stops retaining them once they exceed cap. Past the cap the value can't be replayed as one
+// RESTORE bulk anyway, so the loader streams it as individual commands and no longer needs the
+// raw bytes — dropping them keeps the loader's heap bounded regardless of object size.
+type cappedValueBuffer struct {
+	buf      bytes.Buffer
+	cap      int
+	overflow bool
+}
+
+func newCappedValueBuffer(capBytes uint64) *cappedValueBuffer {
+	const maxInt = int(^uint(0) >> 1)
+	c := maxInt
+	if capBytes < uint64(maxInt) {
+		c = int(capBytes)
+	}
+	return &cappedValueBuffer{cap: c}
+}
+
+// Write implements io.Writer for io.TeeReader. It never short-writes or errors (so it can't
+// disrupt the parse), discarding bytes once the cap is exceeded.
+func (c *cappedValueBuffer) Write(p []byte) (int, error) {
+	if !c.overflow {
+		if c.buf.Len()+len(p) > c.cap {
+			c.overflow = true
+			c.buf.Reset() // release the partial capture; we won't RESTORE this value
+		} else {
+			return c.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func (c *cappedValueBuffer) Bytes() []byte    { return c.buf.Bytes() }
+func (c *cappedValueBuffer) Overflowed() bool { return c.overflow }
+
+// emitCmd sends a single rewritten command downstream as an entry in the current DB.
+func (ld *Loader) emitCmd(argv types.RedisCmd) {
+	e := entry.NewEntry()
+	e.DbId = ld.nowDBId
+	e.Argv = argv
+	ld.ch <- e
+}
+
 func NewLoader(name string, updateFunc func(int64), filPath string, ch chan *entry.Entry) *Loader {
 	ld := new(Loader)
 	ld.ch = ch
@@ -211,53 +259,64 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 			return
 		default:
 			key := structure.ReadString(rd)
-			// Use RESTORE command to properly handle duplicate key behavior (panic/skip/rewrite).
-			// Capture raw value bytes using io.TeeReader
-			var value bytes.Buffer
-			teeReader := io.TeeReader(rd, &value)
+			// Replay small values as a single RESTORE (handles duplicate-key behavior
+			// panic/skip/rewrite). Capture the raw value bytes via io.TeeReader, but CAP the
+			// capture at target_redis_proto_max_bulk_len: a value larger than that can't be
+			// RESTOREd as one bulk anyway, so once it overflows the cap we stop retaining the
+			// raw bytes and stream the object as individual commands instead. This keeps the
+			// loader's heap bounded regardless of object size — a single huge collection (e.g. a
+			// 120M-member zset) used to materialize the whole value plus every rewrite command
+			// in memory and OOM the loader.
+			capBytes := config.Opt.Advanced.TargetRedisProtoMaxBulkLen
+			if capBytes > rdbDumpFrameLen {
+				capBytes -= rdbDumpFrameLen // leave room for the dump frame (typeByte+version+crc)
+			}
+			value := newCappedValueBuffer(capBytes)
+			teeReader := io.TeeReader(rd, value)
 			o := types.ParseObject(teeReader, typeByte, key, ld.isValkey)
 
-			// Rewrite() reads from teeReader in a goroutine. Drain the channel
-			// fully before checking value.Len(), otherwise value is still being
-			// populated and the size check reads 0 — letting oversized values
-			// slip through into RESTORE and blow up the target querybuf.
+			// Rewrite() reads from teeReader in a goroutine, emitting the value as individual
+			// commands. Drain it: while the value still fits the cap, buffer the commands (it may
+			// turn out small enough to RESTORE); the moment the capture overflows the cap, flush
+			// the buffered commands and stream the rest directly — never holding the whole object.
 			cmdC := o.Rewrite()
-			var cmds [][]string
+			var buffered []types.RedisCmd
+			streaming := false
 			for cmd := range cmdC {
-				cmds = append(cmds, cmd)
+				if !streaming && value.Overflowed() {
+					log.Warnf("key=[%s] value exceeds target_redis_proto_max_bulk_len=[%d], streaming as "+
+						"individual commands instead of RESTORE.", key, config.Opt.Advanced.TargetRedisProtoMaxBulkLen)
+					streaming = true
+					for _, c := range buffered {
+						ld.emitCmd(c)
+					}
+					buffered = nil
+				}
+				if streaming {
+					ld.emitCmd(cmd)
+				} else {
+					buffered = append(buffered, cmd)
+				}
 			}
 
-			// dump size = typeByte(1) + value + version(2) + crc(8)
-			dumpSize := uint64(1 + value.Len() + 2 + 8)
-			if dumpSize > config.Opt.Advanced.TargetRedisProtoMaxBulkLen {
-				log.Warnf("key=[%s] dump size=[%d] exceeds target_redis_proto_max_bulk_len, falling back to individual commands. "+
-					"rdb_restore_command_behavior setting may not work correctly for this key.", key, dumpSize)
-				for _, cmd := range cmds {
-					e := entry.NewEntry()
-					e.DbId = ld.nowDBId
-					e.Argv = cmd
-					ld.ch <- e
-				}
+			if streaming {
+				// Whole object already emitted as individual commands; Rewrite()'s leading "del"
+				// gives replace semantics. Apply the expire separately.
 				if ld.expireMs != 0 {
-					e := entry.NewEntry()
-					e.DbId = ld.nowDBId
-					e.Argv = []string{"PEXPIRE", key, strconv.FormatInt(ld.expireMs, 10)}
-					ld.ch <- e
+					ld.emitCmd(types.RedisCmd{"PEXPIRE", key, strconv.FormatInt(ld.expireMs, 10)})
 				}
 			} else {
+				// Small enough: replay as a single RESTORE of the captured raw bytes.
 				pttl := 0
 				if ld.expireMs > 0 {
 					pttl = int(ld.expireMs)
 				}
 				v := ld.createValueDump(typeByte, value.Bytes())
-				argv := []string{"RESTORE", key, strconv.Itoa(pttl), v}
+				argv := types.RedisCmd{"RESTORE", key, strconv.Itoa(pttl), v}
 				if config.Opt.Advanced.RDBRestoreCommandBehavior == "rewrite" {
 					argv = append(argv, "replace")
 				}
-				e := entry.NewEntry()
-				e.DbId = ld.nowDBId
-				e.Argv = argv
-				ld.ch <- e
+				ld.emitCmd(argv)
 			}
 
 			ld.expireMs = 0

--- a/internal/reader/scan_standalone_reader.go
+++ b/internal/reader/scan_standalone_reader.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"RedisShake/internal/client"
 	"RedisShake/internal/client/proto"
@@ -32,6 +33,18 @@ type ScanReaderOptions struct {
 	PreferReplica   bool             `mapstructure:"prefer_replica" default:"false"`
 	Count           int              `mapstructure:"count" default:"1"`
 	SkipUnknownType []string         `mapstructure:"skip_unknown_type" default:"[]"`
+	// DumpParallel is the number of independent source connections that drain
+	// the shared needDumpQueue and run DUMP+PTTL. A single connection caps at
+	// ~22k keys/s (round-trip latency), starving downstream writers. Each worker
+	// pulls keys off the shared channel (no key partitioning needed). Default 1.
+	DumpParallel int `mapstructure:"dump_parallel" default:"1"`
+	// DumpQueueSize bounds the scan()->dump() handoff queue. scan() enumerates
+	// key names far faster than dump() processes them; an unbounded queue buffers
+	// ~the whole keyspace in RAM (OOM on large DBs) and the large live heap also
+	// degrades throughput via GC. The bounded default makes Put() block,
+	// backpressuring scan() to dump() throughput so memory stays flat. Set a
+	// large value to restore the previous effectively-unbounded behavior.
+	DumpQueueSize int `mapstructure:"dump_queue_size" default:"100000"`
 }
 
 type dbKey struct {
@@ -44,16 +57,25 @@ type needRestoreItem struct {
 	key  string
 }
 
-type scanStandaloneReader struct {
-	ctx             context.Context
-	dbs             []int
-	opts            *ScanReaderOptions
-	ch              chan *entry.Entry
-	needDumpQueue   *utils.UniqueQueue
+// dumpWorker is one source connection that drains the shared needDumpQueue.
+// Each worker runs its own dump()/restore() pair on its own connection, so
+// pipelined replies stay ordered per-connection. Workers share needDumpQueue
+// (input) and r.ch (output); the Go channel hands each key to exactly one
+// worker, so no key partitioning is needed.
+type dumpWorker struct {
+	client          *client.Redis
 	needRestoreChan chan *needRestoreItem
-	dumpClient      *client.Redis
-	subWG           sync.WaitGroup
 	isValkey        bool
+}
+
+type scanStandaloneReader struct {
+	ctx           context.Context
+	dbs           []int
+	opts          *ScanReaderOptions
+	ch            chan *entry.Entry
+	needDumpQueue *utils.UniqueQueue
+	subWG         sync.WaitGroup
+	restoreWG     sync.WaitGroup
 
 	stat struct {
 		Name              string `json:"name"`
@@ -71,9 +93,12 @@ func NewScanStandaloneReader(ctx context.Context, opts *ScanReaderOptions) Reade
 	r.opts = opts
 	r.ch = make(chan *entry.Entry, 1024)
 	r.stat.Name = "reader_" + strings.Replace(opts.Address, ":", "_", -1)
-	r.needDumpQueue = utils.NewUniqueQueue(100000000)     // cache 100000000 keys
-	r.needRestoreChan = make(chan *needRestoreItem, 1024) // inflight 1024 keys
-	log.Infof("[%s] scanStandaloneReader init finished. dbs=[%v]", r.stat.Name, r.dbs)
+	queueSize := opts.DumpQueueSize
+	if queueSize < 1 {
+		queueSize = 100000
+	}
+	r.needDumpQueue = utils.NewUniqueQueue(queueSize) // bounded: backpressure scan() to dump() speed (avoids buffering whole keyspace)
+	log.Infof("[%s] scanStandaloneReader init finished. dbs=[%v], dump_queue_size=[%d]", r.stat.Name, r.dbs, queueSize)
 	return r
 }
 
@@ -87,8 +112,25 @@ func (r *scanStandaloneReader) StartRead(ctx context.Context) []chan *entry.Entr
 	if r.opts.Scan {
 		go r.scan()
 	}
-	go r.dump()
-	go r.restore()
+	parallel := r.opts.DumpParallel
+	if parallel < 1 {
+		parallel = 1
+	}
+	log.Infof("[%s] starting %d dump worker(s)", r.stat.Name, parallel)
+	for i := 0; i < parallel; i++ {
+		w := &dumpWorker{
+			client:          client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.TlsConfig, r.opts.PreferReplica),
+			needRestoreChan: make(chan *needRestoreItem, 1024),
+		}
+		r.restoreWG.Add(1)
+		go r.dump(w)
+		go r.restore(w)
+	}
+	// Close the output channel once every worker's restore() has drained.
+	go func() {
+		r.restoreWG.Wait()
+		close(r.ch)
+	}()
 	return []chan *entry.Entry{r.ch}
 }
 
@@ -204,57 +246,86 @@ func (r *scanStandaloneReader) scan() {
 	}
 }
 
-func (r *scanStandaloneReader) dump() {
+func (r *scanStandaloneReader) dump(w *dumpWorker) {
 	nowDbId := 0
-	r.dumpClient = client.NewRedisClient(r.ctx, r.opts.Address, r.opts.Username, r.opts.Password, r.opts.Tls, r.opts.TlsConfig, r.opts.PreferReplica)
-	r.isValkey = r.dumpClient.IsValkey()
-	log.Infof("[%s] detected server type: %s", r.stat.Name, map[bool]string{true: "Valkey", false: "Redis"}[r.isValkey])
+	w.isValkey = w.client.IsValkey()
+	log.Infof("[%s] detected server type: %s", r.stat.Name, map[bool]string{true: "Valkey", false: "Redis"}[w.isValkey])
 	// Support prefer_replica=true in both Cluster and Standalone mode
 	if r.opts.PreferReplica {
-		r.dumpClient.Do("READONLY")
+		w.client.Do("READONLY")
 		log.Infof("running dump() in read-only mode")
 	}
 
-	for item := range r.needDumpQueue.Ch {
-		r.stat.NeedUpdateCount = int64(r.needDumpQueue.Len())
-		dbId := item.(dbKey).db
-		key := item.(dbKey).key
-		if nowDbId != dbId {
-			r.dumpClient.Send("SELECT", strconv.Itoa(dbId))
-			nowDbId = dbId
+	// Batch the DUMP/PTTL sends instead of flushing per command (Send() would do
+	// a syscall per command — the scan reader's dominant cost). Flush every
+	// `flushEvery` keys or every 5ms (whichever first) so restore() is never
+	// starved and a lull can't strand a partial batch. flushEvery stays well
+	// under the needRestoreChan capacity to avoid a send/receive deadlock.
+	const flushEvery = 128
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	pending := 0
+	for {
+		select {
+		case <-ticker.C:
+			if pending > 0 {
+				w.client.Flush()
+				pending = 0
+			}
+			continue
+		case item, ok := <-r.needDumpQueue.Ch:
+			if !ok {
+				if pending > 0 {
+					w.client.Flush()
+				}
+				close(w.needRestoreChan)
+				log.Infof("[%s] scanStandaloneReader dump finished.", r.stat.Name)
+				return
+			}
+			r.stat.NeedUpdateCount = int64(r.needDumpQueue.Len())
+			dbId := item.(dbKey).db
+			key := item.(dbKey).key
+			if nowDbId != dbId {
+				w.client.SendNoFlush("SELECT", strconv.Itoa(dbId))
+				nowDbId = dbId
+			}
+			// dump (buffered; flushed in batches below)
+			w.client.SendNoFlush("DUMP", key)
+			w.client.SendNoFlush("PTTL", key)
+			if len(r.opts.SkipUnknownType) > 0 {
+				w.client.SendNoFlush("TYPE", key)
+			}
+			w.needRestoreChan <- &needRestoreItem{dbId, key}
+			pending++
+			if pending >= flushEvery {
+				w.client.Flush()
+				pending = 0
+			}
 		}
-		// dump
-		r.dumpClient.Send("DUMP", key)
-		r.dumpClient.Send("PTTL", key)
-		if len(r.opts.SkipUnknownType) > 0 {
-			r.dumpClient.Send("TYPE", key)
-		}
-		r.needRestoreChan <- &needRestoreItem{dbId, key}
 	}
-	close(r.needRestoreChan)
-	log.Infof("[%s] scanStandaloneReader dump finished.", r.stat.Name)
 }
 
 // restore sends RESTORE commands to the target Redis.
 // Note: rdb_restore_command_behavior configuration only applies when RESTORE command is used.
 // For large values exceeding target_redis_proto_max_bulk_len, individual commands (SET, HSET, etc.)
 // are used instead, which may not respect the rdb_restore_command_behavior setting.
-func (r *scanStandaloneReader) restore() {
+func (r *scanStandaloneReader) restore(w *dumpWorker) {
+	defer r.restoreWG.Done()
 	nowDbId := 0
-	for item := range r.needRestoreChan {
+	for item := range w.needRestoreChan {
 		dbId := item.dbId
 		key := item.key
 		if nowDbId != dbId {
-			reply, err := r.dumpClient.Receive()
+			reply, err := w.client.Receive()
 			if err != nil || reply != "OK" {
 				log.Panicf("scanStandaloneReader select db failed. db=[%d]", dbId)
 			}
 			nowDbId = dbId
 		}
-		iDump, err1 := r.dumpClient.Receive()
-		iPttl, err2 := r.dumpClient.Receive()
+		iDump, err1 := w.client.Receive()
+		iPttl, err2 := w.client.Receive()
 		if len(r.opts.SkipUnknownType) > 0 {
-			iType, err3 := r.dumpClient.Receive()
+			iType, err3 := w.client.Receive()
 			if err3 != nil {
 				log.Panicf("%v", err3)
 			}
@@ -303,7 +374,7 @@ func (r *scanStandaloneReader) restore() {
 				"rdb_restore_command_behavior setting may not work correctly for this key.", key, len(dump))
 			typeByte := dump[0]
 			anotherReader := strings.NewReader(dump[1 : len(dump)-10])
-			o := types.ParseObject(anotherReader, typeByte, key, r.isValkey)
+			o := types.ParseObject(anotherReader, typeByte, key, w.isValkey)
 			cmdC := o.Rewrite()
 			for cmd := range cmdC {
 				e := entry.NewEntry()
@@ -329,7 +400,6 @@ func (r *scanStandaloneReader) restore() {
 		}
 	}
 	log.Infof("[%s] scanStandaloneReader restore finished.", r.stat.Name)
-	close(r.ch)
 }
 
 func (r *scanStandaloneReader) Status() interface{} {

--- a/internal/writer/redis_standalone_writer.go
+++ b/internal/writer/redis_standalone_writer.go
@@ -26,19 +26,31 @@ type RedisWriterOptions struct {
 	Tls       bool                   `mapstructure:"tls" default:"false"`
 	TlsConfig client.TlsConfig       `mapstructure:"tls_config" default:"{}"`
 	OffReply  bool                   `mapstructure:"off_reply" default:"false"`
+	// Parallel is the number of independent target connections the writer fans
+	// entries out across. The single shared input channel hands each entry to
+	// exactly one connection worker (no key partitioning needed; RESTOREs of
+	// distinct keys are order-independent). Default 1 == original behavior.
+	Parallel  int                    `mapstructure:"parallel" default:"1"`
 	Sentinel  client.SentinelOptions `mapstructure:"sentinel"`
 }
 
-type redisStandaloneWriter struct {
-	address string
-	client  *client.Redis
-	DbId    int
-
+// connWriter is one target connection plus its in-flight reply queue. Each runs
+// its own processWrite/processReply pair; they share the writer's input channel.
+type connWriter struct {
+	client      *client.Redis
 	chWaitReply chan *entry.Entry
-	chWaitWg    sync.WaitGroup
-	offReply    bool
-	ch          chan *entry.Entry
-	chWg        sync.WaitGroup
+	DbId        int
+}
+
+type redisStandaloneWriter struct {
+	address  string
+	conns    []*connWriter
+	offReply bool
+	rl       ratelimit.Limiter // shared: target_redis_max_qps is a global cap
+
+	ch       chan *entry.Entry
+	chWg     sync.WaitGroup // processWrite goroutines
+	chWaitWg sync.WaitGroup // processReply goroutines
 
 	stat struct {
 		Name              string `json:"name"`
@@ -51,33 +63,52 @@ func NewRedisStandaloneWriter(ctx context.Context, opts *RedisWriterOptions) Wri
 	rw := new(redisStandaloneWriter)
 	rw.address = opts.Address
 	rw.stat.Name = "writer_" + strings.Replace(opts.Address, ":", "_", -1)
-	rw.client = client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, false)
+	rw.offReply = opts.OffReply
+
+	parallel := opts.Parallel
+	if parallel < 1 {
+		parallel = 1
+	}
+	rw.rl = ratelimit.New(config.Opt.Advanced.TargetRedisMaxQPS)
+	log.Infof("set target redis max qps to %d (shared across %d writer connections)", config.Opt.Advanced.TargetRedisMaxQPS, parallel)
+
 	rw.ch = make(chan *entry.Entry, config.Opt.Advanced.PipelineCountLimit)
+	rw.conns = make([]*connWriter, parallel)
+	for i := 0; i < parallel; i++ {
+		cw := &connWriter{
+			client: client.NewRedisClient(ctx, opts.Address, opts.Username, opts.Password, opts.Tls, opts.TlsConfig, false),
+		}
+		if opts.OffReply {
+			cw.client.Send("CLIENT", "REPLY", "OFF")
+		} else {
+			cw.chWaitReply = make(chan *entry.Entry, config.Opt.Advanced.PipelineCountLimit*2)
+			rw.chWaitWg.Add(1)
+			go rw.processReply(cw)
+		}
+		rw.conns[i] = cw
+	}
 	if opts.OffReply {
 		log.Infof("turn off the reply of write")
-		rw.offReply = true
-		rw.client.Send("CLIENT", "REPLY", "OFF")
-	} else {
-		rw.chWaitReply = make(chan *entry.Entry, config.Opt.Advanced.PipelineCountLimit*2)
-		rw.chWaitWg.Add(1)
-		go rw.processReply()
 	}
 	return rw
 }
 
 func (w *redisStandaloneWriter) Close() {
+	close(w.ch)
+	w.chWg.Wait()
 	if !w.offReply {
-		close(w.ch)
-		w.chWg.Wait()
-		close(w.chWaitReply)
+		for _, cw := range w.conns {
+			close(cw.chWaitReply)
+		}
 		w.chWaitWg.Wait()
 	}
 }
 
 func (w *redisStandaloneWriter) StartWrite(ctx context.Context) chan *entry.Entry {
-	w.chWg = sync.WaitGroup{}
-	w.chWg.Add(1)
-	go w.processWrite(ctx)
+	for _, cw := range w.conns {
+		w.chWg.Add(1)
+		go w.processWrite(ctx, cw)
+	}
 	return w.ch
 }
 
@@ -85,41 +116,38 @@ func (w *redisStandaloneWriter) Write(e *entry.Entry) {
 	w.ch <- e
 }
 
-func (w *redisStandaloneWriter) switchDbTo(newDbId int) {
+func (w *redisStandaloneWriter) switchDbTo(cw *connWriter, newDbId int) {
 	log.Debugf("[%s] switch db to [%d]", w.stat.Name, newDbId)
-	w.client.Send("select", strconv.Itoa(newDbId))
-	w.DbId = newDbId
+	cw.client.Send("select", strconv.Itoa(newDbId))
+	cw.DbId = newDbId
 	if !w.offReply {
-		w.chWaitReply <- &entry.Entry{
+		cw.chWaitReply <- &entry.Entry{
 			Argv:    []string{"select", strconv.Itoa(newDbId)},
 			CmdName: "select",
 		}
 	}
 }
 
-func (w *redisStandaloneWriter) processWrite(ctx context.Context) {
+func (w *redisStandaloneWriter) processWrite(ctx context.Context, cw *connWriter) {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 
-	var rl ratelimit.Limiter = nil
-	rl = ratelimit.New(config.Opt.Advanced.TargetRedisMaxQPS)
-	log.Infof("set target redis max qps to %d", config.Opt.Advanced.TargetRedisMaxQPS)
 	for {
 		select {
 		case <-ctx.Done():
 			// do nothing until w.ch is closed
 		case <-ticker.C:
-			w.client.Flush()
+			cw.client.Flush()
 		case e, ok := <-w.ch:
 			if !ok {
 				// clean up and exit
-				w.client.Flush()
+				cw.client.Flush()
 				w.chWg.Done()
 				return
 			}
 			// switch db if we need
-			if w.DbId != e.DbId {
-				w.switchDbTo(e.DbId)
+			if cw.DbId != e.DbId {
+				w.switchDbTo(cw, e.DbId)
 			}
 			// send
 			bytes := e.Serialize()
@@ -136,26 +164,26 @@ func (w *redisStandaloneWriter) processWrite(ctx context.Context) {
 				log.Warnf("[%s] entry serialized size=%d exceeds target_redis_client_max_querybuf_len=%d, sending anyway. cmd=[%s] key=[%s]",
 					w.stat.Name, e.SerializedSize, config.Opt.Advanced.TargetRedisClientMaxQuerybufLen, e.CmdName, key)
 			}
-			rl.Take()
+			w.rl.Take()
 			log.Debugf("[%s] send cmd. cmd=[%s]", w.stat.Name, e.String())
 			if !w.offReply {
 				select {
-				case w.chWaitReply <- e:
+				case cw.chWaitReply <- e:
 				default:
-					w.client.Flush()
-					w.chWaitReply <- e
+					cw.client.Flush()
+					cw.chWaitReply <- e
 				}
 				atomic.AddInt64(&w.stat.UnansweredBytes, e.SerializedSize)
 				atomic.AddInt64(&w.stat.UnansweredEntries, 1)
 			}
-			w.client.SendBytesBuff(bytes)
+			cw.client.SendBytesBuff(bytes)
 		}
 	}
 }
 
-func (w *redisStandaloneWriter) processReply() {
-	for e := range w.chWaitReply {
-		reply, err := w.client.Receive()
+func (w *redisStandaloneWriter) processReply(cw *connWriter) {
+	for e := range cw.chWaitReply {
+		reply, err := cw.client.Receive()
 		log.Debugf("[%s] receive reply. reply=[%v], cmd=[%s]", w.stat.Name, reply, e.String())
 
 		// It's good to skip the nil error since some write commands will return the null reply. For example,

--- a/shake.toml
+++ b/shake.toml
@@ -19,6 +19,8 @@ try_diskless = false       # Set to true for diskless sync if the source has rep
 #scan = true                # set to false if you don't want to scan keys
 #ksn = false                # set to true to enabled Redis keyspace notifications (KSN) subscription
 #count = 1                  # number of keys to scan per iteration
+#dump_parallel = 1          # number of source connections draining the scan queue in parallel (DUMP+PTTL); 1 = original behavior
+#dump_queue_size = 100000   # bound on the scan()->dump() handoff queue; backpressures scan to dump speed and keeps memory flat on large DBs. Set very large to restore the old effectively-unbounded behavior
 ## RedisShake uses the TYPE command to get each key's type.
 ## If the type is in this skip list, the key will be skipped.
 #skip_unknown_type = []  # e.g. ["imset", "mbloom", "string", "hash", "list", "set", "zset"]
@@ -37,6 +39,7 @@ username = ""              # keep empty if not using ACL
 password = ""              # keep empty if no authentication is required
 tls = false
 off_reply = false          # turn off the server reply
+parallel = 1               # number of target connections to fan writes across (1 = original behavior)
 
 # [file_writer]
 # filepath = "/tmp/cmd.txt"


### PR DESCRIPTION
## Summary
Throughput & memory improvements for the `scan_reader` (SCAN + DUMP + PTTL + RESTORE) path and the standalone `redis_writer`. On a ~40M-key standalone source, end-to-end scan-based sync went from **~25k to ~280k keys/s** with flat memory.

## Motivation
Migrating a large keyspace (tens of millions of keys) via `scan_reader` — e.g. from a server that can't serve `PSYNC`, like Dragonfly — was throughput- and memory-limited:
- A single source connection doing `DUMP`+`PTTL` per key caps ~22k keys/s on round-trip latency.
- `client.Send()` flushes after **every** command, so each key costs 2 source send syscalls; CPU profiling showed **~64% of time in socket syscalls**.
- `needDumpQueue` is hardcoded to `100_000_000`, so on a large DB it buffers ~the whole keyspace in RAM (OOM), and the large live heap also degrades throughput via GC during scan-fill.
- The standalone writer funnels all entries through one connection.

## Changes
1. **`redis_writer.parallel`** (default `1`, unchanged behavior) — fan RESTOREs across N target connections draining a shared channel.
2. **`scan_reader.dump_parallel`** (default `1`, unchanged behavior) — N source connections running DUMP+PTTL, draining the shared scan queue (the Go channel hands each key to exactly one worker — no key partitioning).
3. **Batched `DUMP`/`PTTL` sends** — add `client.SendNoFlush()`; `dump()` buffers source commands and flushes every 128 keys or 5ms instead of per-command. Amortizes hundreds of commands per syscall — the single biggest win. Internal only (no API change); preserves command/reply ordering.
4. **`scan_reader.dump_queue_size`** (**default `100000`, was an effectively-unbounded hardcoded `100000000`**) — bound the scan→dump handoff queue. The old value buffered ~the whole keyspace in RAM (OOM risk on large DBs) and the oversized live heap hurt throughput via GC; the bounded default backpressures `scan()` to `dump()` speed and keeps memory flat. Set a large value to restore the previous behavior.

## Benchmark (Tens of millions of keys, standalone → standalone)
| config | keys/s |
|---|---|
| stock (1 dump conn, 1 writer conn) | ~22–28k |
| parallel dump+writer (8/8), pre-batching | ~90k |
| + batched sends | **~252k** |
| + `count=50000` | ~282k |

Memory stays ~50 MiB with the bounded queue (vs many GiB unbounded).

## Compatibility
`parallel` and `dump_parallel` default to `1` (no change). The one default change is `dump_queue_size` (100000 vs the old hardcoded 100000000): it caps the in-flight scan buffer — throughput is unaffected or improved (benchmarks above), only peak memory changes (for the better). Set `dump_queue_size` large to opt back into the old unbounded behavior.
