### PR TITLE
test: fix CI compatibility

### DIFF
--- a/tests/cases/sync.py
+++ b/tests/cases/sync.py
@@ -97,10 +97,10 @@ def test_sync_rdb_false():
     # Wait for shake to finish RDB phase and become consistent
     timer = Timer()
     while not shake.is_consistent():
-        if timer.elapsed() > 10:
+        if timer.elapsed() > 60:
             with open(f"{shake.dir}/data/shake.log") as f:
                 pybbt.log(f.read())
-            raise TimeoutError("shake not consistent within 10s")
+            raise TimeoutError("shake not consistent within 60s")
         time.sleep(0.1)
     pybbt.log("shake is consistent after RDB phase skipped")
 

--- a/tests/helpers/cluster.py
+++ b/tests/helpers/cluster.py
@@ -20,7 +20,7 @@ class Cluster:
         self.client = redis.RedisCluster(startup_nodes=[
             ClusterNode(self.nodes[0].host, self.nodes[0].port),
             ClusterNode(self.nodes[1].host, self.nodes[1].port)
-        ], require_full_coverage=True)
+        ], require_full_coverage=True, protocol=2)
         p.ASSERT_EQ_TIMEOUT(lambda: self.client.cluster_info()["cluster_state"], "ok", 10)
 
         # Wait for all nodes to be connected and cluster is truly ready

--- a/tests/helpers/redis.py
+++ b/tests/helpers/redis.py
@@ -24,7 +24,7 @@ class Redis:
         self.server = pybbt.Launcher(args=[PATH_REDIS_SERVER] + args, work_dir=self.dir)
 
         self._wait_start()
-        self.client = redis.Redis(host=self.host, port=self.port)
+        self.client = redis.Redis(host=self.host, port=self.port, protocol=2)
         self.case_ctx.add_exit_hook(lambda: self.server.stop())
         pybbt.log_yellow(f"redis server started at {self.host}:{self.port}, redis-cli -p {self.port}")
 
@@ -32,7 +32,7 @@ class Redis:
         timer = Timer()
         while True:
             try:
-                r = redis.Redis(host=self.host, port=self.port)
+                r = redis.Redis(host=self.host, port=self.port, protocol=2)
                 r.ping()
                 return
             except redis.exceptions.ConnectionError:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.31.0
 toml>=0.10.2
-redis>=4.5.4
+redis>=5.0.0
 rich>=13.0.0


### PR DESCRIPTION
## Summary

- Force RESP2 for Redis and Redis Cluster test clients.
- Raise the redis-py minimum version to 5.0.0, where the `protocol` argument was introduced.
- Increase the standalone `sync_rdb=false` consistency timeout from 10 seconds to 60 seconds.

## Root cause

redis-py 8.x defaults to RESP3 and sends `HELLO 3`, which Redis 2.8-5.0 do not support. The `sync_rdb=false` test also raced the replication heartbeat at its independent 10-second timeout.

## Validation

- `go test ./...`
- Python syntax compilation for the changed test files
- redis-py 5.0.0 and 8.1.0 accept `protocol=2`

Follow-up for Actions run 32017066269.